### PR TITLE
Feat/image provider grid

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,7 @@ To get in-app video for the sources you will also need to run the [Caspar CG Ima
 
 ##### Extra CasparCG setup for the image provider
 
-The image provider app needs an extra (empty) channel in CasparCG.
-
-Additionally, you must set a full path to the media folder in the CasparCG configuration. Relative paths (typically `/media`) won't suffice.
+The image provider app needs an extra (empty) channel in CasparCG in order to stream previews to the web app.
 
 ### Development
 

--- a/app.ts
+++ b/app.ts
@@ -1,5 +1,5 @@
-import { BrowserWindow, app } from 'electron';
+import { BrowserWindow, app } from 'electron'
 
-import Main from './server/main';
+import Main from './server/main'
 
-Main.main(app, BrowserWindow);
+Main.main(app, BrowserWindow)

--- a/client/index.js
+++ b/client/index.js
@@ -1,13 +1,13 @@
-const { ipcRenderer } = require('electron');
+const { ipcRenderer } = require('electron')
 
-import CutoutManager from './scripts/cutout-manager.js';
-import { write } from '../lib/config.js';
-import { EventNames } from '../shared/events.js';
+import CutoutManager from './scripts/cutout-manager.js'
+import { write } from '../lib/config.js'
+import { EventNames } from '../shared/events.js'
 
-new CutoutManager(ipcRenderer);
+new CutoutManager(ipcRenderer)
 
 ipcRenderer.on(EventNames.UPDATE_CONFIG, (event, newFullConfig) => {
 	// A new config is received from the backend.
-	write(newFullConfig);
-	document.dispatchEvent(new CustomEvent(EventNames.UPDATE_CONFIG));
-});
+	write(newFullConfig)
+	document.dispatchEvent(new CustomEvent(EventNames.UPDATE_CONFIG))
+})

--- a/client/scripts/cutout-manager.js
+++ b/client/scripts/cutout-manager.js
@@ -2,142 +2,142 @@ import {
 	attributeNames as videoCropperAttributeNames,
 	tagName as videoCropperTagName,
 	eventNames as videoCropperEventNames
-} from '../../components/video/video-cropper.js';
+} from '../../components/video/video-cropper.js'
 
 import {
 	tagName as sourceSelectorTagName,
 	eventNames as sourceSelectorEventNames,
 	attributeNames as sourceSelectorAttributeNames
-} from '../../components/video/source-selector.js';
+} from '../../components/video/source-selector.js'
 
 import {
 	createCutoutFromSource,
 	findCutoutIdFromSourceId,
 	getCutoutSourceId
-} from '../../lib/cutouts.js';
+} from '../../lib/cutouts.js'
 
-import { EventNames as applicationEvents } from '../../shared/events.js';
+import { EventNames as applicationEvents } from '../../shared/events.js'
 
-import * as config from '../../lib/config.js';
-import { eventNames as directTakeToggleEvents } from '../../components/ui/direct-take-toggle.js';
+import * as config from '../../lib/config.js'
+import { eventNames as directTakeToggleEvents } from '../../components/ui/direct-take-toggle.js'
 
 export default class CutoutManager {
 	constructor(ipcRenderer) {
-		this.ipcRenderer = ipcRenderer;
+		this.ipcRenderer = ipcRenderer
 
-		this.setupEventListeners();
+		this.setupEventListeners()
 
 		this.ipcRenderer.on(applicationEvents.BACKEND_READY, () => {
-			const sourceIds = Object.keys(config.get('sources'));
+			const sourceIds = Object.keys(config.get('sources'))
 			if (sourceIds[0]) {
-				this.selectSource(sourceIds[0]);
+				this.selectSource(sourceIds[0])
 			}
-		});
+		})
 
-		this.ipcRenderer.send(applicationEvents.BACKEND_INITIALIZE);
+		this.ipcRenderer.send(applicationEvents.BACKEND_INITIALIZE)
 
-		this.directTakeMode = false;
+		this.directTakeMode = false
 	}
 
 	setupEventListeners() {
 		document.addEventListener(sourceSelectorEventNames.SOURCE_SELECTED, ({ detail }) => {
-			this.selectSource(detail.id);
-		});
+			this.selectSource(detail.id)
+		})
 
 		document.addEventListener(videoCropperEventNames.CROP_MOVE, ({ detail }) => {
 			if (detail) {
-				this.moveCrop(detail);
+				this.moveCrop(detail)
 			}
-		});
+		})
 
 		document.addEventListener('click', ({ target }) => {
 			if (target.classList.contains('take-controls--button') && target.classList.contains('take')) {
-				this.take();
+				this.take()
 			}
-		});
+		})
 
 		document.addEventListener(directTakeToggleEvents.ACTIVATE, () => {
-			this.directTakeMode = true;
-		});
+			this.directTakeMode = true
+		})
 
 		document.addEventListener(directTakeToggleEvents.DEACTIVATE, () => {
-			this.directTakeMode = false;
-		});
+			this.directTakeMode = false
+		})
 	}
 
 	moveCrop({ cutoutId, cutout }) {
 		if (cutoutId && cutout) {
-			this.triggerSendUpdate(cutoutId, cutout);
+			this.triggerSendUpdate(cutoutId, cutout)
 
-			config.set(`cutouts.${cutoutId}`, cutout);
+			config.set(`cutouts.${cutoutId}`, cutout)
 		}
 	}
 
 	selectSource(id) {
-		let cutoutId = findCutoutIdFromSourceId(id);
+		let cutoutId = findCutoutIdFromSourceId(id)
 
 		if (!cutoutId) {
-			const cutout = createCutoutFromSource(id);
+			const cutout = createCutoutFromSource(id)
 			if (cutout) {
-				cutoutId = `cutout_${id}`;
-				this.ipcRenderer.send(applicationEvents.UPDATE_CUTOUT, cutoutId, cutout);
+				cutoutId = `cutout_${id}`
+				this.ipcRenderer.send(applicationEvents.UPDATE_CUTOUT, cutoutId, cutout)
 			}
 		}
 
 		if (cutoutId) {
 			if (this.directTakeMode === true) {
-				this.setProgram(cutoutId);
+				this.setProgram(cutoutId)
 			} else {
-				this.setPreview(cutoutId);
+				this.setPreview(cutoutId)
 			}
 		}
 	}
 
 	take() {
-		const preview = document.querySelector(`${videoCropperTagName}.preview`);
-		const program = document.querySelector(`${videoCropperTagName}.program`);
+		const preview = document.querySelector(`${videoCropperTagName}.preview`)
+		const program = document.querySelector(`${videoCropperTagName}.program`)
 
-		const cutoutOnPreviewId = preview.getAttribute(videoCropperAttributeNames.CUTOUT_ID);
-		const cutoutOnProgramId = program.getAttribute(videoCropperAttributeNames.CUTOUT_ID);
+		const cutoutOnPreviewId = preview.getAttribute(videoCropperAttributeNames.CUTOUT_ID)
+		const cutoutOnProgramId = program.getAttribute(videoCropperAttributeNames.CUTOUT_ID)
 
-		const cutouts = config.get('cutouts');
+		const cutouts = config.get('cutouts')
 		if (cutoutOnPreviewId && cutouts[cutoutOnPreviewId]) {
-			this.setProgram(cutoutOnPreviewId);
-			this.setPreview(cutoutOnProgramId);
+			this.setProgram(cutoutOnPreviewId)
+			this.setPreview(cutoutOnProgramId)
 		}
 	}
 
 	setPreview(cutoutId) {
-		const preview = document.querySelector(`${videoCropperTagName}.preview`);
-		const sourceId = getCutoutSourceId(cutoutId);
+		const preview = document.querySelector(`${videoCropperTagName}.preview`)
+		const sourceId = getCutoutSourceId(cutoutId)
 
-		preview.setAttribute(videoCropperAttributeNames.CUTOUT_ID, cutoutId);
+		preview.setAttribute(videoCropperAttributeNames.CUTOUT_ID, cutoutId)
 		document.querySelectorAll(sourceSelectorTagName).forEach((sourceSelector) => {
-			sourceSelector.setAttribute(sourceSelectorAttributeNames.PREVIEW_ID, sourceId);
-		});
+			sourceSelector.setAttribute(sourceSelectorAttributeNames.PREVIEW_ID, sourceId)
+		})
 
-		this.ipcRenderer.send(applicationEvents.SET_PREVIEW, cutoutId);
+		this.ipcRenderer.send(applicationEvents.SET_PREVIEW, cutoutId)
 	}
 
 	setProgram(cutoutId) {
-		const program = document.querySelector(`${videoCropperTagName}.program`);
-		const sourceId = getCutoutSourceId(cutoutId);
+		const program = document.querySelector(`${videoCropperTagName}.program`)
+		const sourceId = getCutoutSourceId(cutoutId)
 
-		program.setAttribute(videoCropperAttributeNames.CUTOUT_ID, cutoutId);
+		program.setAttribute(videoCropperAttributeNames.CUTOUT_ID, cutoutId)
 		document.querySelectorAll(sourceSelectorTagName).forEach((sourceSelector) => {
-			sourceSelector.setAttribute(sourceSelectorAttributeNames.PROGRAM_ID, sourceId);
-		});
+			sourceSelector.setAttribute(sourceSelectorAttributeNames.PROGRAM_ID, sourceId)
+		})
 
-		this.ipcRenderer.send(applicationEvents.TAKE, cutoutId);
+		this.ipcRenderer.send(applicationEvents.TAKE, cutoutId)
 	}
 
 	triggerSendUpdate(cutoutId, cutout) {
 		if (!this.sendUpdateTimeout) {
 			this.sendUpdateTimeout = setTimeout(() => {
-				this.sendUpdateTimeout = null;
+				this.sendUpdateTimeout = null
 
-				this.ipcRenderer.send(applicationEvents.UPDATE_CUTOUT, cutoutId, cutout);
-			}, 40);
+				this.ipcRenderer.send(applicationEvents.UPDATE_CUTOUT, cutoutId, cutout)
+			}, 40)
 		}
 	}
 }

--- a/components/components.js
+++ b/components/components.js
@@ -1,5 +1,5 @@
 // ui components
 
-import './video/video-cropper.js';
-import './video/source-selector.js';
-import './ui/direct-take-toggle.js';
+import './video/video-cropper.js'
+import './video/source-selector.js'
+import './ui/direct-take-toggle.js'

--- a/components/ui/direct-take-toggle.js
+++ b/components/ui/direct-take-toggle.js
@@ -1,43 +1,43 @@
-export { tagName, eventNames };
+export { tagName, eventNames }
 
-const tagName = 'direct-take-toggle';
+const tagName = 'direct-take-toggle'
 
 const eventNames = {
 	ACTIVATE: 'direct-take-activated',
 	DEACTIVATE: 'direct-take-deactivated'
-};
+}
 
 const classNames = {
 	ARMED: 'armed'
-};
+}
 
 class DirectTakeToggle extends HTMLButtonElement {
 	constructor() {
-		super();
+		super()
 	}
 
 	connectedCallback() {
 		this.addEventListener('click', () => {
-			this.handleClick();
-		});
+			this.handleClick()
+		})
 	}
 
 	handleClick() {
 		if (this.classList.contains(classNames.ARMED)) {
-			this.deactivate();
+			this.deactivate()
 		} else {
-			this.activate();
+			this.activate()
 		}
 	}
 
 	deactivate() {
-		this.classList.remove(classNames.ARMED);
-		this.dispatchEvent(new CustomEvent(eventNames.DEACTIVATE, { composed: true, bubbles: true }));
+		this.classList.remove(classNames.ARMED)
+		this.dispatchEvent(new CustomEvent(eventNames.DEACTIVATE, { composed: true, bubbles: true }))
 	}
 
 	activate() {
-		this.classList.add(classNames.ARMED);
-		this.dispatchEvent(new CustomEvent(eventNames.ACTIVATE, { composed: true, bubbles: true }));
+		this.classList.add(classNames.ARMED)
+		this.dispatchEvent(new CustomEvent(eventNames.ACTIVATE, { composed: true, bubbles: true }))
 	}
 }
-customElements.define(tagName, DirectTakeToggle, { extends: 'button' });
+customElements.define(tagName, DirectTakeToggle, { extends: 'button' })

--- a/components/video/source-thumbnail.js
+++ b/components/video/source-thumbnail.js
@@ -43,8 +43,6 @@ class SourceThumbnail extends HTMLElement {
 		if (isDefined(contentId)) {
 			const video = document.createElement(videoDisplayTagName)
 			video.setAttribute(videoDisplayAttributeNames.STREAM_CONTENT_ID, contentId)
-			// video.setAttribute(videoDisplayAttributeNames.STREAM_CHANNEL, channel);
-			// video.setAttribute(videoDisplayAttributeNames.STREAM_LAYER, layer);
 			video.classList.add(classNames.VIDEO_DISPLAY)
 			this.shadowRoot.appendChild(video)
 		} else {

--- a/components/video/source-thumbnail.js
+++ b/components/video/source-thumbnail.js
@@ -1,58 +1,59 @@
 import {
 	tagName as videoDisplayTagName,
 	attributeNames as videoDisplayAttributeNames
-} from './video-display.js';
-import { get as getConfigValue } from '../../lib/config.js';
+} from './video-display.js'
+import { get as getConfigValue } from '../../lib/config.js'
 
-const html = String.raw;
+const html = String.raw
 
-export { tagName, attributeNames };
+export { tagName, attributeNames }
 
-const tagName = 'source-thumbnail';
+const tagName = 'source-thumbnail'
 
 const attributeNames = {
 	SOURCE_ID: 'data-source-id'
-};
+}
 
 const classNames = {
 	VIDEO_DISPLAY: 'source-thumbnail--video'
-};
+}
 
 const template = html`
 	<link rel="stylesheet" href="./components/video/source-thumbnail.css" />
-`;
+`
 
 class SourceThumbnail extends HTMLElement {
 	constructor() {
-		super();
+		super()
 
-		this.attachShadow({ mode: 'open' });
-		this.shadowRoot.innerHTML = template;
+		this.attachShadow({ mode: 'open' })
+		this.shadowRoot.innerHTML = template
 	}
 
 	connectedCallback() {
-		const sourceId = this.getAttribute(attributeNames.SOURCE_ID);
+		const sourceId = this.getAttribute(attributeNames.SOURCE_ID)
 		if (!isDefined(sourceId)) {
-			console.warn(`No source id set, unable to display thumbnail.`);
-			return;
+			console.warn(`No source id set, unable to display thumbnail.`)
+			return
 		}
 
-		const sourceReferenceLayers = getConfigValue('sourceReferenceLayers');
-		const { channel, layer } = sourceReferenceLayers[sourceId];
+		const sourceReferenceLayers = getConfigValue('sourceReferenceLayers')
+		const { contentId } = sourceReferenceLayers[sourceId]
 
-		if (isDefined(channel) && isDefined(layer)) {
-			const video = document.createElement(videoDisplayTagName);
-			video.setAttribute(videoDisplayAttributeNames.STREAM_CHANNEL, channel);
-			video.setAttribute(videoDisplayAttributeNames.STREAM_LAYER, layer);
-			video.classList.add(classNames.VIDEO_DISPLAY);
-			this.shadowRoot.appendChild(video);
+		if (isDefined(contentId)) {
+			const video = document.createElement(videoDisplayTagName)
+			video.setAttribute(videoDisplayAttributeNames.STREAM_CONTENT_ID, contentId)
+			// video.setAttribute(videoDisplayAttributeNames.STREAM_CHANNEL, channel);
+			// video.setAttribute(videoDisplayAttributeNames.STREAM_LAYER, layer);
+			video.classList.add(classNames.VIDEO_DISPLAY)
+			this.shadowRoot.appendChild(video)
 		} else {
-			console.warn(`Channel and/or layer not found for source ${sourceId}`);
+			console.warn(`Channel and/or layer not found for source ${sourceId}`)
 		}
 	}
 }
-customElements.define(tagName, SourceThumbnail);
+customElements.define(tagName, SourceThumbnail)
 
 function isDefined(value) {
-	return value !== null && value !== undefined;
+	return value !== null && value !== undefined
 }

--- a/components/video/video-cropper.js
+++ b/components/video/video-cropper.js
@@ -2,134 +2,136 @@ import {
 	tagName as videoDisplayTagName,
 	attributeNames as videoDisplayAttributeNames,
 	eventNames as videoDisplayEventNames
-} from './video-display.js';
+} from './video-display.js'
 
 import {
 	tagName as cropToolTagName,
 	attributeNames as cropToolAttributeNames,
 	eventNames as cropToolEventNames
-} from './cutout-window.js';
-import { get as getConfigValue } from '../../lib/config.js';
-import { EventNames } from '../../shared/events.js';
+} from './cutout-window.js'
+import { get as getConfigValue } from '../../lib/config.js'
+import { EventNames } from '../../shared/events.js'
 
-const html = String.raw;
+const html = String.raw
 
-export { tagName, attributeNames, eventNames };
+export { tagName, attributeNames, eventNames }
 
-const tagName = 'video-cropper';
+const tagName = 'video-cropper'
 
 /* These must be kept in sync with this element's stylesheet */
 const classNames = {
 	CONTAINER: 'video-cropper--container',
 	CONTENT: 'video-cropper--content'
-};
+}
 
 const attributeNames = {
 	CUTOUT_ID: 'data-cutout-id'
-};
+}
 
 const eventNames = {
 	CROP_MOVE: 'crop-move'
-};
+}
 
 const template = html`
 	<link rel="stylesheet" href="./components/video/video-cropper.css" />
 	<div class="${classNames.CONTAINER}"></div>
-`;
+`
 
 class VideoCropper extends HTMLElement {
 	constructor() {
-		super();
+		super()
 
-		const shadowRoot = this.attachShadow({ mode: 'open' });
-		shadowRoot.innerHTML = template;
+		const shadowRoot = this.attachShadow({ mode: 'open' })
+		shadowRoot.innerHTML = template
 
-		this.container = shadowRoot.querySelector(`.${classNames.CONTAINER}`);
+		this.container = shadowRoot.querySelector(`.${classNames.CONTAINER}`)
 
-		this.videoDisplay = document.createElement(videoDisplayTagName);
-		this.videoDisplay.classList.add(classNames.CONTENT);
-		this.container.appendChild(this.videoDisplay);
+		this.videoDisplay = document.createElement(videoDisplayTagName)
+		this.videoDisplay.classList.add(classNames.CONTENT)
+		this.container.appendChild(this.videoDisplay)
 
-		this.cropTool = document.createElement(cropToolTagName);
-		this.cropTool.classList.add(classNames.CONTENT);
-		this.container.appendChild(this.cropTool);
+		this.cropTool = document.createElement(cropToolTagName)
+		this.cropTool.classList.add(classNames.CONTENT)
+		this.container.appendChild(this.cropTool)
 	}
 
 	static get observedAttributes() {
-		return Object.values(attributeNames);
+		return Object.values(attributeNames)
 	}
 
 	attributeChangedCallback(name, oldValue, newValue) {
 		switch (name) {
 			case attributeNames.CUTOUT_ID:
 				if (newValue) {
-					this.updateId(newValue);
+					this.updateId(newValue)
 				}
-				break;
+				break
 		}
 	}
 
 	connectedCallback() {
 		if (this.hasAttribute(attributeNames.CUTOUT_ID)) {
-			this.updateId(this.getAttribute(attributeNames.CUTOUT_ID));
+			this.updateId(this.getAttribute(attributeNames.CUTOUT_ID))
 		}
 
 		this.addEventListener(videoDisplayEventNames.STREAM_PLAYING, () => {
-			this.cropTool.dispatchEvent(new CustomEvent(cropToolEventNames.UPDATE_FRAME_SIZE));
-		});
+			this.cropTool.dispatchEvent(new CustomEvent(cropToolEventNames.UPDATE_FRAME_SIZE))
+		})
 
 		this.addEventListener(cropToolEventNames.MOVE, (event) => {
-			event.stopPropagation();
-			const { width, height, x, y } = event.detail;
-			const centeredPosition = transformTopLeftToCenterOrigo({ x, y, width, height }, this.source);
+			event.stopPropagation()
+			const { width, height, x, y } = event.detail
+			const centeredPosition = transformTopLeftToCenterOrigo({ x, y, width, height }, this.source)
 			this.cutout = Object.assign({}, this.cutout, {
 				width,
 				height,
 				x: centeredPosition.x,
 				y: centeredPosition.y
-			});
-			this.triggerSendUpdate();
-		});
+			})
+			this.triggerSendUpdate()
+		})
 
 		document.addEventListener(EventNames.UPDATE_CONFIG, () => {
 			if (this.cutoutId) {
-				this.updateId(this.cutoutId);
+				this.updateId(this.cutoutId)
 			}
-		});
+		})
 	}
 
 	updateId(id) {
-		const cutouts = getConfigValue('cutouts');
-		const sources = getConfigValue('sources');
-		const sourceReferenceLayers = getConfigValue('sourceReferenceLayers');
+		const cutouts = getConfigValue('cutouts')
+		const sources = getConfigValue('sources')
+		const sourceReferenceLayers = getConfigValue('sourceReferenceLayers')
 
 		if (!cutouts[id]) {
-			this.cutoutId = null;
-			this.source = null;
-			this.cropTool.setAttribute(cropToolAttributeNames.CUTOUT, '');
-			this.videoDisplay.setAttribute(videoDisplayAttributeNames.STREAM_CHANNEL, '');
-			this.videoDisplay.setAttribute(videoDisplayAttributeNames.STREAM_LAYER, '');
-			return;
+			this.cutoutId = null
+			this.source = null
+			this.cropTool.setAttribute(cropToolAttributeNames.CUTOUT, '')
+			this.videoDisplay.setAttribute(videoDisplayAttributeNames.STREAM_CONTENT_ID, '')
+			// this.videoDisplay.setAttribute(videoDisplayAttributeNames.STREAM_CHANNEL, '');
+			// this.videoDisplay.setAttribute(videoDisplayAttributeNames.STREAM_LAYER, '');
+			return
 		}
 
-		this.cutoutId = id;
-		this.cutout = Object.assign({}, cutouts[id]);
-		const sourceId = this.cutout.source;
-		this.source = sources[sourceId];
+		this.cutoutId = id
+		this.cutout = Object.assign({}, cutouts[id])
+		const sourceId = this.cutout.source
+		this.source = sources[sourceId]
 
-		const topLeftPosition = transformCenterToTopLeft(this.cutout, this.source);
-		const topLeftCutout = Object.assign({}, this.cutout, topLeftPosition);
-		this.cropTool.setAttribute(cropToolAttributeNames.CUTOUT, JSON.stringify(topLeftCutout));
+		const topLeftPosition = transformCenterToTopLeft(this.cutout, this.source)
+		const topLeftCutout = Object.assign({}, this.cutout, topLeftPosition)
+		this.cropTool.setAttribute(cropToolAttributeNames.CUTOUT, JSON.stringify(topLeftCutout))
 
-		const { channel, layer } = sourceReferenceLayers[sourceId];
-		this.videoDisplay.setAttribute(videoDisplayAttributeNames.STREAM_CHANNEL, channel);
-		this.videoDisplay.setAttribute(videoDisplayAttributeNames.STREAM_LAYER, layer);
+		const { contentId } = sourceReferenceLayers[sourceId]
+		this.videoDisplay.setAttribute(videoDisplayAttributeNames.STREAM_CONTENT_ID, contentId)
+		// this.videoDisplay.setAttribute(videoDisplayAttributeNames.STREAM_CHANNEL, channel);
+		// this.videoDisplay.setAttribute(videoDisplayAttributeNames.STREAM_LAYER, layer);
 	}
 
 	triggerSendUpdate() {
 		if (!this.sendUpdateTimeout) {
 			this.sendUpdateTimeout = setTimeout(() => {
-				this.sendUpdateTimeout = null;
+				this.sendUpdateTimeout = null
 
 				const event = new CustomEvent(eventNames.CROP_MOVE, {
 					bubbles: true,
@@ -138,31 +140,31 @@ class VideoCropper extends HTMLElement {
 						cutoutId: this.cutoutId,
 						cutout: this.cutout
 					}
-				});
-				this.dispatchEvent(event);
-			}, 40);
+				})
+				this.dispatchEvent(event)
+			}, 40)
 		}
 	}
 }
 
-customElements.define(tagName, VideoCropper);
+customElements.define(tagName, VideoCropper)
 
 function transformTopLeftToCenterOrigo(cutout, source) {
-	const cutoutOrigoX = cutout.x + cutout.width / 2;
-	const cutoutOrigoY = cutout.y + cutout.height / 2;
+	const cutoutOrigoX = cutout.x + cutout.width / 2
+	const cutoutOrigoY = cutout.y + cutout.height / 2
 
 	return {
 		x: cutoutOrigoX - source.width / 2,
 		y: cutoutOrigoY - source.height / 2
-	};
+	}
 }
 
 function transformCenterToTopLeft(cutout, source) {
-	const cutoutOrigoX = cutout.x - cutout.width / 2;
-	const cutoutOrigoY = cutout.y - cutout.height / 2;
+	const cutoutOrigoX = cutout.x - cutout.width / 2
+	const cutoutOrigoY = cutout.y - cutout.height / 2
 
 	return {
 		x: cutoutOrigoX + source.width / 2,
 		y: cutoutOrigoY + source.height / 2
-	};
+	}
 }

--- a/components/video/video-cropper.js
+++ b/components/video/video-cropper.js
@@ -108,8 +108,6 @@ class VideoCropper extends HTMLElement {
 			this.source = null
 			this.cropTool.setAttribute(cropToolAttributeNames.CUTOUT, '')
 			this.videoDisplay.setAttribute(videoDisplayAttributeNames.STREAM_CONTENT_ID, '')
-			// this.videoDisplay.setAttribute(videoDisplayAttributeNames.STREAM_CHANNEL, '');
-			// this.videoDisplay.setAttribute(videoDisplayAttributeNames.STREAM_LAYER, '');
 			return
 		}
 
@@ -124,8 +122,6 @@ class VideoCropper extends HTMLElement {
 
 		const { contentId } = sourceReferenceLayers[sourceId]
 		this.videoDisplay.setAttribute(videoDisplayAttributeNames.STREAM_CONTENT_ID, contentId)
-		// this.videoDisplay.setAttribute(videoDisplayAttributeNames.STREAM_CHANNEL, channel);
-		// this.videoDisplay.setAttribute(videoDisplayAttributeNames.STREAM_LAYER, layer);
 	}
 
 	triggerSendUpdate() {

--- a/components/video/video-display.js
+++ b/components/video/video-display.js
@@ -1,16 +1,17 @@
-import { getElementWidth } from '../../lib/dimensions.js';
-import { getImageProviderLocation } from '../../lib/config.js';
+import { getElementWidth } from '../../lib/dimensions.js'
+import { getImageProviderLocation } from '../../lib/config.js'
 
-const html = String.raw;
+const html = String.raw
 
-export { tagName, attributeNames, eventNames };
+export { tagName, attributeNames, eventNames }
 
-const tagName = 'video-display';
+const tagName = 'video-display'
 
 const attributeNames = {
-	STREAM_CHANNEL: 'data-stream-channel',
-	STREAM_LAYER: 'data-stream-layer'
-};
+	STREAM_CONTENT_ID: 'data-stream-channel'
+	// STREAM_CHANNEL: 'data-stream-channel',
+	// STREAM_LAYER: 'data-stream-layer'
+}
 
 /*
   WARNING: These class names are also used in the stylesheet, and so they must
@@ -20,11 +21,11 @@ const classNames = {
 	CONTAINER: 'video-display--container',
 	AR_PLACEHOLDER: 'ar-placeholder',
 	IMG: 'img'
-};
+}
 
 const eventNames = {
 	STREAM_PLAYING: 'stream-playing'
-};
+}
 
 const template = html`
 	<link rel="stylesheet" href="./components/video/video-display.css" />
@@ -32,7 +33,7 @@ const template = html`
 		<div class="${classNames.AR_PLACEHOLDER}"></div>
 		<img class="${classNames.IMG}" />
 	</div>
-`;
+`
 
 /**
  * A custom element for displaying a video stream provided by an instance
@@ -41,136 +42,146 @@ const template = html`
  */
 class VideoDisplay extends HTMLElement {
 	static get observedAttributes() {
-		return Object.values(attributeNames);
+		return Object.values(attributeNames)
 	}
 
 	constructor() {
-		super();
+		super()
 
-		const shadowRoot = this.attachShadow({ mode: 'open' });
-		shadowRoot.innerHTML = template;
+		const shadowRoot = this.attachShadow({ mode: 'open' })
+		shadowRoot.innerHTML = template
 
-		this.streamChannel = this.getAttribute(attributeNames.STREAM_CHANNEL);
-		this.streamLayer = this.getAttribute(attributeNames.STREAM_LAYER);
+		this.streamContentId = this.getAttribute(attributeNames.STREAM_CONTENT_ID)
+		// this.streamChannel = this.getAttribute(attributeNames.STREAM_CHANNEL);
+		// this.streamLayer = this.getAttribute(attributeNames.STREAM_LAYER);
 	}
 
 	connectedCallback() {
-		const img = this.shadowRoot.querySelector(`img.${classNames.IMG}`);
+		const img = this.shadowRoot.querySelector(`img.${classNames.IMG}`)
 		img.addEventListener('load', () => {
-			this.dispatchStreamPlaying();
-		});
+			this.dispatchStreamPlaying()
+		})
 		img.addEventListener('error', function(e) {
-			console.warn('Error loading video stream', e);
-		});
+			console.warn('Error loading video stream', e)
+		})
 
-		this.loadStream();
+		this.loadStream()
 
 		// https://developer.mozilla.org/en-US/docs/Web/API/Resize_Observer_API
 		const resizeObserver = new ResizeObserver(() => {
-			this.resize();
-		});
-		resizeObserver.observe(this);
+			this.resize()
+		})
+		resizeObserver.observe(this)
 	}
 
 	attributeChangedCallback(name, oldValue, currentValue) {
 		switch (name) {
-			case attributeNames.STREAM_CHANNEL:
-				if (this.streamChannel !== currentValue) {
-					this.streamChannel = currentValue;
-					this.loadStream();
+			case attributeNames.STREAM_CONTENT_ID:
+				if (this.streamContentId !== currentValue) {
+					this.streamContentId = currentValue
+					this.loadStream()
 				}
-				break;
-			case attributeNames.STREAM_LAYER:
-				if (this.streamLayer !== currentValue) {
-					this.streamLayer = currentValue;
-					this.loadStream();
-				}
-				break;
+				break
+			// case attributeNames.STREAM_CHANNEL:
+			// 	if (this.streamChannel !== currentValue) {
+			// 		this.streamChannel = currentValue;
+			// 		this.loadStream();
+			// 	}
+			// 	break;
+			// case attributeNames.STREAM_LAYER:
+			// 	if (this.streamLayer !== currentValue) {
+			// 		this.streamLayer = currentValue;
+			// 		this.loadStream();
+			// 	}
+			// 	break;
 		}
 	}
 
 	dispatchStreamPlaying() {
-		const event = new CustomEvent(eventNames.STREAM_PLAYING, { bubbles: true, composed: true });
-		this.dispatchEvent(event);
+		const event = new CustomEvent(eventNames.STREAM_PLAYING, { bubbles: true, composed: true })
+		this.dispatchEvent(event)
 	}
 
 	loadStream() {
-		const img = this.shadowRoot.querySelector(`img.${classNames.IMG}`);
+		const img = this.shadowRoot.querySelector(`img.${classNames.IMG}`)
 
-		if (!this.streamChannel || !this.streamLayer) {
-			console.warn(
-				`Unable to load stream, missing data: channel: ${this.streamChannel}, layer: ${this.streamLayer}`
-			);
-			img.src = 'data:,'; // could use a placeholder?
-			img.setAttribute('alt', '');
-			return;
+		// if (!this.streamChannel || !this.streamLayer) {
+		if (!this.streamContentId) {
+			console.warn(`Unable to load stream, missing data: streamContentId: ${this.streamContentId}`)
+			img.src = 'data:,' // could use a placeholder?
+			img.setAttribute('alt', '')
+			return
 		}
 
-		const imageProviderLocation = getImageProviderLocation();
-		const streamUrl = `${imageProviderLocation}/channel/${this.streamChannel}/${this.streamLayer}/stream`;
+		const imageProviderLocation = getImageProviderLocation()
+		// const streamUrl = `${imageProviderLocation}/channel/${this.streamChannel}/${this.streamLayer}/stream`;
+		const streamUrl = `${imageProviderLocation}/info`
 
 		fetch(streamUrl)
 			.then((response) => response.json())
 			.then((streamInfo) => {
-				const region = streamInfo.regions.find(
-					(r) => r.layer === this.streamLayer && r.channel === this.streamChannel
-				);
+				// const region = streamInfo.regions.find(
+				// 	(r) => r.layer === this.streamLayer && r.channel === this.streamChannel
+				// );
+				const region = streamInfo.regions.find((r) => r.contentId === this.streamContentId)
 				if (!region) {
-					throw new Error(`Region for channel ${this.streamChannel} not found using ${streamUrl}`);
+					throw new Error(
+						`Region for contentId ${this.streamContentId} not found using ${streamUrl}`
+					)
 				}
 
-				this.region = region;
-				const stream = streamInfo.streams.find((s) => s.id == region.streamId);
+				this.region = region
+				const stream = streamInfo.streams.find((s) => s.id == region.streamId)
 				if (!stream) {
-					throw new Error(`Stream ${region.streamId} not found`);
+					throw new Error(`Stream ${region.streamId} not found`)
 				}
 
-				const srcUrl = imageProviderLocation + stream.url;
+				const srcUrl = imageProviderLocation + stream.url
 				if (img.src !== srcUrl) {
-					img.src = srcUrl;
+					img.src = srcUrl
 				} else {
-					this.dispatchStreamPlaying();
+					this.dispatchStreamPlaying()
 				}
 
-				this.resize();
+				this.resize()
 			})
-			.catch(console.error);
+			.catch(console.error)
 	}
 
 	resize() {
 		if (!this.region) {
-			return;
+			return
 		}
 
-		const img = this.shadowRoot.querySelector(`img.${classNames.IMG}`);
-		const container = this.shadowRoot.querySelector(`.${classNames.CONTAINER}`);
-		const arPlaceholder = this.shadowRoot.querySelector(`.${classNames.AR_PLACEHOLDER}`);
-		const scale = calcTransformScale(this.shadowRoot.host, this.region);
+		const img = this.shadowRoot.querySelector(`img.${classNames.IMG}`)
+		const container = this.shadowRoot.querySelector(`.${classNames.CONTAINER}`)
+		const arPlaceholder = this.shadowRoot.querySelector(`.${classNames.AR_PLACEHOLDER}`)
+		const scale = calcTransformScale(this.shadowRoot.host, this.region)
 		const containerDimensions = {
 			width: Math.round(this.region.width * scale),
 			height: Math.round(this.region.height * scale)
-		};
+		}
 
-		img.style.transform = getCSSTransformString(scale, this.region);
-		container.style.width = containerDimensions.width;
-		arPlaceholder.style.paddingBottom = `${containerDimensions.height}px`;
+		img.style.transform = getCSSTransformString(scale, this.region)
+		container.style.width = containerDimensions.width
+		arPlaceholder.style.paddingBottom = `${containerDimensions.height}px`
 	}
 }
 
-customElements.define(tagName, VideoDisplay);
+customElements.define(tagName, VideoDisplay)
 
 function calcTransformScale(container, region) {
-	const width = getElementWidth(container);
-	return width / region.width;
+	const width = getElementWidth(container)
+	return width / region.width
 }
 
 function getCSSTransformString(scale, region) {
 	/* Note that the transforms depend on transform-origin: top left, which is
 	set in the component stylesheet */
-	const transforms = [];
+	const transforms = []
 
-	transforms.push(`scale3d(${scale},${scale}, 1)`);
-	transforms.push(`translate3d(${-region.x}px, ${-region.y}px, 0)`);
+	transforms.push(`scale3d(${scale},${scale}, 1)`)
+	transforms.push(`translate3d(${-region.x}px, ${-region.y}px, 0)`)
 
-	return transforms.join(' ');
+	return transforms.join(' ')
 }

--- a/components/video/video-display.js
+++ b/components/video/video-display.js
@@ -8,9 +8,7 @@ export { tagName, attributeNames, eventNames }
 const tagName = 'video-display'
 
 const attributeNames = {
-	STREAM_CONTENT_ID: 'data-stream-channel'
-	// STREAM_CHANNEL: 'data-stream-channel',
-	// STREAM_LAYER: 'data-stream-layer'
+	STREAM_CONTENT_ID: 'data-stream-content-id'
 }
 
 /*
@@ -52,8 +50,6 @@ class VideoDisplay extends HTMLElement {
 		shadowRoot.innerHTML = template
 
 		this.streamContentId = this.getAttribute(attributeNames.STREAM_CONTENT_ID)
-		// this.streamChannel = this.getAttribute(attributeNames.STREAM_CHANNEL);
-		// this.streamLayer = this.getAttribute(attributeNames.STREAM_LAYER);
 	}
 
 	connectedCallback() {
@@ -75,25 +71,11 @@ class VideoDisplay extends HTMLElement {
 	}
 
 	attributeChangedCallback(name, oldValue, currentValue) {
-		switch (name) {
-			case attributeNames.STREAM_CONTENT_ID:
-				if (this.streamContentId !== currentValue) {
-					this.streamContentId = currentValue
-					this.loadStream()
-				}
-				break
-			// case attributeNames.STREAM_CHANNEL:
-			// 	if (this.streamChannel !== currentValue) {
-			// 		this.streamChannel = currentValue;
-			// 		this.loadStream();
-			// 	}
-			// 	break;
-			// case attributeNames.STREAM_LAYER:
-			// 	if (this.streamLayer !== currentValue) {
-			// 		this.streamLayer = currentValue;
-			// 		this.loadStream();
-			// 	}
-			// 	break;
+		if (name === attributeNames.STREAM_CONTENT_ID) {
+			if (this.streamContentId !== currentValue) {
+				this.streamContentId = currentValue
+				this.loadStream()
+			}
 		}
 	}
 
@@ -105,7 +87,6 @@ class VideoDisplay extends HTMLElement {
 	loadStream() {
 		const img = this.shadowRoot.querySelector(`img.${classNames.IMG}`)
 
-		// if (!this.streamChannel || !this.streamLayer) {
 		if (!this.streamContentId) {
 			console.warn(`Unable to load stream, missing data: streamContentId: ${this.streamContentId}`)
 			img.src = 'data:,' // could use a placeholder?
@@ -114,23 +95,19 @@ class VideoDisplay extends HTMLElement {
 		}
 
 		const imageProviderLocation = getImageProviderLocation()
-		// const streamUrl = `${imageProviderLocation}/channel/${this.streamChannel}/${this.streamLayer}/stream`;
 		const streamUrl = `${imageProviderLocation}/info`
 
 		fetch(streamUrl)
 			.then((response) => response.json())
 			.then((streamInfo) => {
-				// const region = streamInfo.regions.find(
-				// 	(r) => r.layer === this.streamLayer && r.channel === this.streamChannel
-				// );
 				const region = streamInfo.regions.find((r) => r.contentId === this.streamContentId)
 				if (!region) {
 					throw new Error(
 						`Region for contentId ${this.streamContentId} not found using ${streamUrl}`
 					)
 				}
-
 				this.region = region
+
 				const stream = streamInfo.streams.find((s) => s.id == region.streamId)
 				if (!stream) {
 					throw new Error(`Stream ${region.streamId} not found`)

--- a/config/cutouts.json
+++ b/config/cutouts.json
@@ -6,7 +6,7 @@
 			"outputRotation": 0,
 			"source": "source_B",
 			"width": 1080,
-			"x": -81.07317073170748,
+			"x": -235.85244136510482,
 			"y": 0
 		},
 		"cutout_source_D": {
@@ -22,7 +22,7 @@
 			"outputRotation": 0,
 			"source": "source_A",
 			"width": 1080,
-			"x": -143.70731707317066,
+			"x": 309.5748326389212,
 			"y": 0
 		},
 		"cutout_source_E": {

--- a/config/settings.json
+++ b/config/settings.json
@@ -1,5 +1,6 @@
 {
 	"settings": {
+		"useImageProviderForRoutes": true,
 		"channelForRoutes": 1,
 		"channelForRoutesStartLayer": 900,
 

--- a/config/settings.json
+++ b/config/settings.json
@@ -5,11 +5,11 @@
 		"channelForRoutesStartLayer": 900,
 
 		"casparCG": {
-			"hostname": "sacaspar03",
+			"hostname": "127.0.0.1",
 			"port": 5250
 		},
 		"imageProvider": {
-			"hostname": "sacaspar03",
+			"hostname": "127.0.0.1",
 			"port": 5255,
 			"protocol": "http"
 		},

--- a/lib/aspect-ratios-test.js
+++ b/lib/aspect-ratios-test.js
@@ -1,102 +1,102 @@
-import { assert } from '@sinonjs/referee';
-import { aspectRatios, calcAspectRatio } from './aspect-ratios.js';
+import { assert } from '@sinonjs/referee'
+import { aspectRatios, calcAspectRatio } from './aspect-ratios.js'
 
 describe('lib/aspect-ratios', () => {
 	describe('calcAspectRatios', () => {
 		describe('16:9 resolutions', () => {
 			it('should return 16_9 for 1280x720', () => {
-				const input = { width: 1280, height: 720 };
-				const expected = aspectRatios['16_9'];
+				const input = { width: 1280, height: 720 }
+				const expected = aspectRatios['16_9']
 
-				const actual = calcAspectRatio(input);
+				const actual = calcAspectRatio(input)
 
-				assert.equals(actual, expected);
-			});
+				assert.equals(actual, expected)
+			})
 
 			it('should return 16_9 for 1920x1080', () => {
-				const input = { width: 1920, height: 1080 };
-				const expected = aspectRatios['16_9'];
+				const input = { width: 1920, height: 1080 }
+				const expected = aspectRatios['16_9']
 
-				const actual = calcAspectRatio(input);
+				const actual = calcAspectRatio(input)
 
-				assert.equals(actual, expected);
-			});
+				assert.equals(actual, expected)
+			})
 
 			it('should return 16_9 for 256x144', () => {
-				const input = { width: 256, height: 144 };
-				const expected = aspectRatios['16_9'];
+				const input = { width: 256, height: 144 }
+				const expected = aspectRatios['16_9']
 
-				const actual = calcAspectRatio(input);
+				const actual = calcAspectRatio(input)
 
-				assert.equals(actual, expected);
-			});
+				assert.equals(actual, expected)
+			})
 
 			it('should return 16_9 for 768x432', () => {
-				const input = { width: 768, height: 432 };
-				const expected = aspectRatios['16_9'];
+				const input = { width: 768, height: 432 }
+				const expected = aspectRatios['16_9']
 
-				const actual = calcAspectRatio(input);
+				const actual = calcAspectRatio(input)
 
-				assert.equals(actual, expected);
-			});
-		});
+				assert.equals(actual, expected)
+			})
+		})
 
 		describe('9:16 resolutions', () => {
 			it('should return 9_16 for 720x1280', () => {
-				const input = { width: 720, height: 1280 };
-				const expected = aspectRatios['9_16'];
+				const input = { width: 720, height: 1280 }
+				const expected = aspectRatios['9_16']
 
-				const actual = calcAspectRatio(input);
+				const actual = calcAspectRatio(input)
 
-				assert.equals(actual, expected);
-			});
+				assert.equals(actual, expected)
+			})
 
 			it('should return 9_16 for 1080x1920', () => {
-				const input = { width: 1080, height: 1920 };
-				const expected = aspectRatios['9_16'];
+				const input = { width: 1080, height: 1920 }
+				const expected = aspectRatios['9_16']
 
-				const actual = calcAspectRatio(input);
+				const actual = calcAspectRatio(input)
 
-				assert.equals(actual, expected);
-			});
+				assert.equals(actual, expected)
+			})
 
 			it('should return 9_16 for 144x256', () => {
-				const input = { width: 144, height: 256 };
-				const expected = aspectRatios['9_16'];
+				const input = { width: 144, height: 256 }
+				const expected = aspectRatios['9_16']
 
-				const actual = calcAspectRatio(input);
+				const actual = calcAspectRatio(input)
 
-				assert.equals(actual, expected);
-			});
+				assert.equals(actual, expected)
+			})
 
 			it('should return 9_16 for 432x768', () => {
-				const input = { width: 432, height: 768 };
-				const expected = aspectRatios['9_16'];
+				const input = { width: 432, height: 768 }
+				const expected = aspectRatios['9_16']
 
-				const actual = calcAspectRatio(input);
+				const actual = calcAspectRatio(input)
 
-				assert.equals(actual, expected);
-			});
-		});
+				assert.equals(actual, expected)
+			})
+		})
 
 		describe('1:1 resolutions', () => {
 			it('should return 1_1 for 1x1', () => {
-				const input = { width: 1, height: 1 };
-				const expected = aspectRatios['1_1'];
+				const input = { width: 1, height: 1 }
+				const expected = aspectRatios['1_1']
 
-				const actual = calcAspectRatio(input);
+				const actual = calcAspectRatio(input)
 
-				assert.equals(actual, expected);
-			});
+				assert.equals(actual, expected)
+			})
 
 			it('should return 1_1 for 1280x1280', () => {
-				const input = { width: 1280, height: 1280 };
-				const expected = aspectRatios['1_1'];
+				const input = { width: 1280, height: 1280 }
+				const expected = aspectRatios['1_1']
 
-				const actual = calcAspectRatio(input);
+				const actual = calcAspectRatio(input)
 
-				assert.equals(actual, expected);
-			});
-		});
-	});
-});
+				assert.equals(actual, expected)
+			})
+		})
+	})
+})

--- a/lib/aspect-ratios.js
+++ b/lib/aspect-ratios.js
@@ -1,11 +1,11 @@
-export { calcAspectRatio, aspectRatios };
+export { calcAspectRatio, aspectRatios }
 
 const aspectRatios = {
 	'16_9': 16 / 9,
 	'1_1': 1,
 	'9_16': 9 / 16
-};
+}
 
 function calcAspectRatio({ width, height }) {
-	return width / height;
+	return width / height
 }

--- a/lib/config-test.js
+++ b/lib/config-test.js
@@ -1,60 +1,60 @@
-import { assert, refute } from '@sinonjs/referee';
-import deepFreeze from 'deep-freeze-es6';
+import { assert, refute } from '@sinonjs/referee'
+import deepFreeze from 'deep-freeze-es6'
 
-import { get, set, write } from './config.js';
+import { get, set, write } from './config.js'
 
 describe('Config module', () => {
 	beforeEach(() => {
-		write({});
-	});
+		write({})
+	})
 
 	describe('get/set', () => {
 		it('should handle a root level property', () => {
-			const path = 'lol';
-			const expected = 'some value';
+			const path = 'lol'
+			const expected = 'some value'
 
-			set(path, expected);
-			const actual = get(path);
+			set(path, expected)
+			const actual = get(path)
 
-			assert.equals(actual, expected);
-		});
+			assert.equals(actual, expected)
+		})
 
 		it('should handle a sublevel property', () => {
-			const path = 'lol.hehe';
-			const expected = 'some other value';
+			const path = 'lol.hehe'
+			const expected = 'some other value'
 
-			set(path, expected);
-			const actual = get(path);
+			set(path, expected)
+			const actual = get(path)
 
-			assert.equals(actual, expected);
-		});
+			assert.equals(actual, expected)
+		})
 
 		it('should preserve existing values for properties that are already objects', () => {
-			const existingConfig = { lol: { hehe: 'an existing value' } };
-			const expectedPreserved = existingConfig.lol.hehe;
-			const path = 'lol.haha';
-			const expected = 'yet another value';
+			const existingConfig = { lol: { hehe: 'an existing value' } }
+			const expectedPreserved = existingConfig.lol.hehe
+			const path = 'lol.haha'
+			const expected = 'yet another value'
 
-			write(existingConfig);
-			set(path, expected);
-			const actual = get(path);
-			const preserved = get('lol.hehe');
+			write(existingConfig)
+			set(path, expected)
+			const actual = get(path)
+			const preserved = get('lol.hehe')
 
-			assert.equals(actual, expected);
-			refute.isUndefined(preserved);
-			assert.equals(preserved, expectedPreserved);
-		});
-	});
+			assert.equals(actual, expected)
+			refute.isUndefined(preserved)
+			assert.equals(preserved, expectedPreserved)
+		})
+	})
 
 	describe('write', () => {
 		it('should clone the value so that changes to the config does not change the original input', () => {
-			const existingConfig = { lol: { hehe: 'an existing value' } };
-			deepFreeze(existingConfig);
+			const existingConfig = { lol: { hehe: 'an existing value' } }
+			deepFreeze(existingConfig)
 
-			write(existingConfig);
-			set('lol.haha', 'a value by any other value');
+			write(existingConfig)
+			set('lol.haha', 'a value by any other value')
 
-			assert(true, 'Test did not throw an error.');
-		});
-	});
-});
+			assert(true, 'Test did not throw an error.')
+		})
+	})
+})

--- a/lib/config.js
+++ b/lib/config.js
@@ -1,6 +1,6 @@
-export { get, getImageProviderLocation, set, write };
+export { get, getImageProviderLocation, set, write }
 
-let config = {};
+let config = {}
 
 /**
  * Get a property value from the config
@@ -10,16 +10,16 @@ let config = {};
  * @return {*|undefined} the value requested or undefined if not existing in config
  */
 function get(path) {
-	let value = undefined;
+	let value = undefined
 
-	const parts = path.split('.');
+	const parts = path.split('.')
 	if (parts.length) {
 		value = parts.reduce((value, propName) => {
-			return value !== null && value !== undefined ? value[propName] : null;
-		}, config);
+			return value !== null && value !== undefined ? value[propName] : null
+		}, config)
 	}
 
-	return value;
+	return value
 }
 
 /**
@@ -31,20 +31,20 @@ function get(path) {
  * @param {*} value - value to set. null or undefined is allowed.
  */
 function set(path, value) {
-	const parts = path.split('.');
-	let current = config;
+	const parts = path.split('.')
+	let current = config
 	parts.forEach((propName, idx) => {
 		if (idx === parts.length - 1) {
-			current[propName] = value;
-			return;
+			current[propName] = value
+			return
 		}
 
 		if (current[propName] === undefined) {
-			current[propName] = {};
+			current[propName] = {}
 		}
-		current = current[propName];
-	});
-	return;
+		current = current[propName]
+	})
+	return
 }
 
 /**
@@ -53,11 +53,11 @@ function set(path, value) {
  * @returns {string} - string representation of the location for the image provider service
  */
 function getImageProviderLocation() {
-	const imageProvider = get('settings.imageProvider');
-	const protocol = imageProvider.protocol ? `${imageProvider.protocol}://` : '';
-	const port = imageProvider.port ? `:${imageProvider.port}` : '';
+	const imageProvider = get('settings.imageProvider')
+	const protocol = imageProvider.protocol ? `${imageProvider.protocol}://` : ''
+	const port = imageProvider.port ? `:${imageProvider.port}` : ''
 
-	return `${protocol}${imageProvider.hostname}${port}`;
+	return `${protocol}${imageProvider.hostname}${port}`
 }
 
 /**
@@ -70,5 +70,5 @@ function getImageProviderLocation() {
  * @param {object} newConfig - the new config
  */
 function write(newConfig) {
-	config = JSON.parse(JSON.stringify(newConfig));
+	config = JSON.parse(JSON.stringify(newConfig))
 }

--- a/lib/conversion.js
+++ b/lib/conversion.js
@@ -1,10 +1,10 @@
-export { arrayBufferToBase64 };
+export { arrayBufferToBase64 }
 
 function arrayBufferToBase64(buffer) {
-	var binary = '';
-	var bytes = [].slice.call(new Uint8Array(buffer));
+	var binary = ''
+	var bytes = [].slice.call(new Uint8Array(buffer))
 
-	bytes.forEach((b) => (binary += String.fromCharCode(b)));
+	bytes.forEach((b) => (binary += String.fromCharCode(b)))
 
-	return window.btoa(binary);
+	return window.btoa(binary)
 }

--- a/lib/cutouts.js
+++ b/lib/cutouts.js
@@ -1,16 +1,16 @@
-import { get as getConfigValue } from './config.js';
+import { get as getConfigValue } from './config.js'
 
-export { createCutoutFromSource, findCutoutIdFromSourceId, getCutoutSourceId };
+export { createCutoutFromSource, findCutoutIdFromSourceId, getCutoutSourceId }
 
 function createCutoutFromSource(sourceId) {
-	const sources = getConfigValue('sources');
+	const sources = getConfigValue('sources')
 	if (!sources) {
-		return undefined;
+		return undefined
 	}
 
-	const source = sources[sourceId];
+	const source = sources[sourceId]
 	if (!source) {
-		return undefined;
+		return undefined
 	}
 
 	return {
@@ -20,20 +20,20 @@ function createCutoutFromSource(sourceId) {
 		source: sourceId,
 		x: 0,
 		y: 0
-	};
+	}
 }
 
 function findCutoutIdFromSourceId(sourceId) {
-	const cutouts = getConfigValue('cutouts');
+	const cutouts = getConfigValue('cutouts')
 	if (cutouts) {
-		return Object.keys(cutouts).find((cutoutId) => cutouts[cutoutId].source === sourceId);
+		return Object.keys(cutouts).find((cutoutId) => cutouts[cutoutId].source === sourceId)
 	}
 
-	return undefined;
+	return undefined
 }
 
 function getCutoutSourceId(cutoutId) {
-	const cutout = getConfigValue(`cutouts.${cutoutId}`);
+	const cutout = getConfigValue(`cutouts.${cutoutId}`)
 
-	return cutout ? cutout.source : null;
+	return cutout ? cutout.source : null
 }

--- a/lib/dimensions.js
+++ b/lib/dimensions.js
@@ -1,4 +1,4 @@
-export { getElementHeight, getElementWidth };
+export { getElementHeight, getElementWidth }
 
 /**
  * Replicates the behavior of jQuery's width() function. Note that it's only
@@ -10,17 +10,17 @@ export { getElementHeight, getElementWidth };
  * @returns the calculated width of the element excluding padding
  */
 function getElementWidth(element) {
-	const { width, paddingLeft, paddingRight } = window.getComputedStyle(element);
-	const computedWidth = Number(width);
+	const { width, paddingLeft, paddingRight } = window.getComputedStyle(element)
+	const computedWidth = Number(width)
 
 	if (!Number.isNaN(computedWidth)) {
-		return computedWidth;
+		return computedWidth
 	}
 
-	const computedPaddingLeft = paddingLeft ? Number.parseInt(paddingLeft, 10) : 0;
-	const computedPaddingRight = paddingRight ? Number.parseInt(paddingRight, 10) : 0;
+	const computedPaddingLeft = paddingLeft ? Number.parseInt(paddingLeft, 10) : 0
+	const computedPaddingRight = paddingRight ? Number.parseInt(paddingRight, 10) : 0
 
-	return element.offsetWidth - computedPaddingLeft - computedPaddingRight;
+	return element.offsetWidth - computedPaddingLeft - computedPaddingRight
 }
 
 /**
@@ -33,15 +33,15 @@ function getElementWidth(element) {
  * @returns the calculated height of the element excluding padding
  */
 function getElementHeight(element) {
-	const { height, paddingTop, paddingBottom } = window.getComputedStyle(element);
-	const computedHeight = Number(height);
+	const { height, paddingTop, paddingBottom } = window.getComputedStyle(element)
+	const computedHeight = Number(height)
 
 	if (!Number.isNaN(computedHeight)) {
-		return computedHeight;
+		return computedHeight
 	}
 
-	const computedPaddingTop = paddingTop ? Number.parseInt(paddingTop, 10) : 0;
-	const computedPaddingBottom = paddingBottom ? Number.parseInt(paddingBottom, 10) : 0;
+	const computedPaddingTop = paddingTop ? Number.parseInt(paddingTop, 10) : 0
+	const computedPaddingBottom = paddingBottom ? Number.parseInt(paddingBottom, 10) : 0
 
-	return element.scrollHeight - computedPaddingTop - computedPaddingBottom;
+	return element.scrollHeight - computedPaddingTop - computedPaddingBottom
 }

--- a/lib/math.js
+++ b/lib/math.js
@@ -1,5 +1,5 @@
-export { clamp };
+export { clamp }
 
 function clamp(value, min, max) {
-	return Math.min(max, Math.max(value, min));
+	return Math.min(max, Math.max(value, min))
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -668,6 +668,14 @@
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
       "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ=="
     },
+    "axios": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.2.tgz",
+      "integrity": "sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==",
+      "requires": {
+        "follow-redirects": "1.5.10"
+      }
+    },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
@@ -2282,6 +2290,29 @@
             "jsonfile": "^4.0.0",
             "universalify": "^0.1.0"
           }
+        }
+      }
+    },
+    "follow-redirects": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
+      "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
+      "requires": {
+        "debug": "=3.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
 	"cpu": [
 		"x64"
 	],
-	"main": "app.js",
+	"main": "build/app.js",
 	"scripts": {
 		"build": "rimraf build && tsc",
 		"prestart": "npm run build",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
 		"package": "node -r esm scripts/package.js"
 	},
 	"dependencies": {
+		"axios": "^0.19.2",
 		"chokidar": "^3.3.0",
 		"timeline-state-resolver": "^3.18.0",
 		"transformation-matrix": "^2.2.0",

--- a/scripts/remove-serialport.js
+++ b/scripts/remove-serialport.js
@@ -1,5 +1,5 @@
-import trash from 'trash';
+import trash from 'trash'
 
 export default async () => {
-	await trash(['node_modules/@serialport', 'node_modules/serialport']);
-};
+	await trash(['node_modules/@serialport', 'node_modules/serialport'])
+}

--- a/server/CasparReferrer.ts
+++ b/server/CasparReferrer.ts
@@ -8,47 +8,47 @@ import {
 	TimelineObjCCGInput,
 	TimelineObjCCGMedia,
 	TimelineObjCCGRoute
-} from 'timeline-state-resolver';
-import { SourceInputAny, SourceInputType } from './api';
+} from 'timeline-state-resolver'
+import { SourceInputAny, SourceInputType } from './api'
 
-import { DecklinkInputRefs } from './TSRController';
+import { DecklinkInputRefs } from './TSRController'
 
 export class CasparReferrer {
-	decklingInputRefs: DecklinkInputRefs = {};
+	decklingInputRefs: DecklinkInputRefs = {}
 	reset(): void {
-		this.decklingInputRefs = {};
+		this.decklingInputRefs = {}
 	}
 	getSourceRef(input: SourceInputAny): string {
 		if (input.type === SourceInputType.MEDIA) {
-			return this.mediaRef(input.file);
+			return this.mediaRef(input.file)
 		} else if (input.type === SourceInputType.DECKLINK) {
-			return this.inputRef('decklink', input.device, input.format);
+			return this.inputRef('decklink', input.device, input.format)
 		} else if (input.type === SourceInputType.HTML_PAGE) {
-			return this.htmlPageRef(input.url);
+			return this.htmlPageRef(input.url)
 		} else {
-			const { type } = input;
-			throw new Error(`Unknown input.type "${type}"`);
+			const { type } = input
+			throw new Error(`Unknown input.type "${type}"`)
 		}
 	}
 	getSource(input: SourceInputAny, layer: string, mixer: Mixer): TSRTimelineObj {
 		if (input.type === SourceInputType.MEDIA) {
-			return this.media(layer, input.file, mixer);
+			return this.media(layer, input.file, mixer)
 		} else if (input.type === SourceInputType.DECKLINK) {
-			return this.input(layer, 'decklink', input.device, input.format, mixer);
+			return this.input(layer, 'decklink', input.device, input.format, mixer)
 		} else if (input.type === SourceInputType.HTML_PAGE) {
-			return this.htmlPage(layer, input.url, mixer);
+			return this.htmlPage(layer, input.url, mixer)
 		} else {
-			const { type } = input;
-			throw new Error(`Unknown input.type "${type}"`);
+			const { type } = input
+			throw new Error(`Unknown input.type "${type}"`)
 		}
 	}
 	mediaRef(file: string): string {
-		return 'media_' + file;
+		return 'media_' + file
 	}
 	media(layer: string, file: string, mixer?: Mixer): TimelineObjCCGMedia | TimelineObjCCGRoute {
-		const refId = this.mediaRef(file);
-		const ref = this.getRef(refId, layer, mixer);
-		if (ref) return ref;
+		const refId = this.mediaRef(file)
+		const ref = this.getRef(refId, layer, mixer)
+		if (ref) return ref
 		const o: TimelineObjCCGMedia = {
 			id: '',
 			layer: layer,
@@ -60,12 +60,12 @@ export class CasparReferrer {
 				loop: true,
 				mixer: mixer
 			}
-		};
-		this.setRef(refId, layer);
-		return o;
+		}
+		this.setRef(refId, layer)
+		return o
 	}
 	inputRef(inputType: string, device: number, deviceFormat: ChannelFormat): string {
-		return 'input_' + inputType + '_' + device + '_' + deviceFormat;
+		return 'input_' + inputType + '_' + device + '_' + deviceFormat
 	}
 	input(
 		layer: string,
@@ -74,9 +74,9 @@ export class CasparReferrer {
 		deviceFormat: ChannelFormat,
 		mixer?: Mixer
 	): TimelineObjCCGInput | TimelineObjCCGRoute {
-		const refId = this.inputRef(inputType, device, deviceFormat);
-		const ref = this.getRef(refId, layer, mixer);
-		if (ref) return ref;
+		const refId = this.inputRef(inputType, device, deviceFormat)
+		const ref = this.getRef(refId, layer, mixer)
+		if (ref) return ref
 		const o: TimelineObjCCGInput = {
 			id: '',
 			layer: layer,
@@ -89,21 +89,21 @@ export class CasparReferrer {
 				inputType: inputType,
 				mixer: mixer
 			}
-		};
-		this.setRef(refId, layer);
-		return o;
+		}
+		this.setRef(refId, layer)
+		return o
 	}
 	htmlPageRef(url: string): string {
-		return 'htmlpage_' + url;
+		return 'htmlpage_' + url
 	}
 	htmlPage(
 		layer: string,
 		url: string,
 		mixer?: Mixer
 	): TimelineObjCCGHTMLPage | TimelineObjCCGRoute {
-		const refId = this.htmlPageRef(url);
-		const ref = this.getRef(refId, layer, mixer);
-		if (ref) return ref;
+		const refId = this.htmlPageRef(url)
+		const ref = this.getRef(refId, layer, mixer)
+		if (ref) return ref
 		const o: TimelineObjCCGHTMLPage = {
 			id: '',
 			layer: layer,
@@ -114,12 +114,12 @@ export class CasparReferrer {
 				url: url,
 				mixer: mixer
 			}
-		};
-		this.setRef(refId, layer);
-		return o;
+		}
+		this.setRef(refId, layer)
+		return o
 	}
 	getRef(refId: string, layer: string, mixer?: Mixer): TimelineObjCCGRoute | undefined {
-		const ref = this.decklingInputRefs[refId];
+		const ref = this.decklingInputRefs[refId]
 		if (ref) {
 			return {
 				id: '',
@@ -131,10 +131,10 @@ export class CasparReferrer {
 					mappedLayer: ref,
 					mixer: mixer
 				}
-			};
+			}
 		}
 	}
 	private setRef(refId, layer): void {
-		this.decklingInputRefs[refId] = layer;
+		this.decklingInputRefs[refId] = layer
 	}
 }

--- a/server/TSRController.ts
+++ b/server/TSRController.ts
@@ -5,7 +5,7 @@ import {
 	DeviceType,
 	Mixer,
 	TSRTimeline
-} from 'timeline-state-resolver';
+} from 'timeline-state-resolver'
 import {
 	Cutout,
 	Cutouts,
@@ -17,156 +17,238 @@ import {
 	Settings,
 	SourceInputAny,
 	FullConfig
-} from './api';
-import { Matrix, applyToPoint, compose, rotateDEG, scale, translate } from 'transformation-matrix';
+} from './api'
+import { Matrix, applyToPoint, compose, rotateDEG, scale, translate } from 'transformation-matrix'
 
-import { CasparReferrer } from './CasparReferrer';
-import _ from 'underscore';
+import { CasparReferrer } from './CasparReferrer'
+import _ from 'underscore'
+import querystring from 'querystring'
+import { getImageProviderLocation } from './imageProvider'
+import axios from 'axios'
+
+const CASPARCG_DEVICE_ID = 'casparcg0'
 
 export class TSRController {
-	private tsr: Conductor;
-	private _tsrDevices: { [deviceId: string]: DeviceContainer } = {};
+	private tsr: Conductor
+	private _tsrDevices: { [deviceId: string]: DeviceContainer } = {}
 
-	public timeline: TSRTimeline = [];
-	public mappings: any = {};
+	public timeline: TSRTimeline = []
+	public mappings: any = {}
 
-	public refer: CasparReferrer;
+	public refer: CasparReferrer
 
-	private _memorySources: { [channelLayer: string]: SourceInputAny } = {};
+	private _memorySources: { [channelLayer: string]: SourceInputAny } = {}
+	private _updateTimelineRunning?: boolean
+	private _nextUpdateTimeline?: {
+		fullConfig: FullConfig
+		runtimeData: RunTimeData
+		resolve: (() => void)[]
+		reject: ((e: any) => void)[]
+	}
 
 	constructor() {
-		this.refer = new CasparReferrer();
+		this.refer = new CasparReferrer()
 		this.tsr = new Conductor({
 			initializeAsClear: true,
 			multiThreadedResolver: false,
 			proActiveResolve: true
-		});
+		})
 
 		this.tsr.on('error', (e, ...args) => {
-			console.error('Error: TSR', e, ...args);
-		});
+			console.error('Error: TSR', e, ...args)
+		})
 		this.tsr.on('info', (msg, ...args) => {
 			// console.log('TSR', msg, ...args)
-		});
+		})
 		this.tsr.on('warning', (msg, ...args) => {
-			console.log('Warning: TSR', msg, ...args);
-		});
+			console.log('Warning: TSR', msg, ...args)
+		})
 		this.tsr.on('debug', (msg, ...args) => {
 			// console.log('Debug: TSR', msg, ...args)
-		});
+		})
 		// this.tsr.on('setTimelineTriggerTime', (_r: TimelineTriggerTimeResult) => {})
 		// this.tsr.on('timelineCallback', (_time, _objId, _callbackName, _data) => {})
 	}
 	async init(fullConfig: FullConfig): Promise<void> {
-		console.log('TSR init');
-		await this.tsr.init();
-		let host = '127.0.0.1';
-		let port = 5250;
+		console.log('TSR init')
+		await this.tsr.init()
+		let host = '127.0.0.1'
+		let port = 5250
 
 		if (fullConfig.settings && fullConfig.settings.casparCG) {
-			host = fullConfig.settings.casparCG.hostname;
-			port = fullConfig.settings.casparCG.port;
+			host = fullConfig.settings.casparCG.hostname
+			port = fullConfig.settings.casparCG.port
 		}
 
 		// TODO: Move info config file:
-		this._addTSRDevice('casparcg0', {
+		this._addTSRDevice(CASPARCG_DEVICE_ID, {
 			type: DeviceType.CASPARCG,
 			options: {
 				host,
 				port
 			},
 			isMultiThreaded: false
-		});
+		})
 
 		// this.updateTimeline()
 	}
 	async destroy(): Promise<void> {
-		await this.tsr.destroy();
+		await this.tsr.destroy()
+	}
+	/**
+	 * Ensure there's only one updateTimeline running at the same time
+	 * If an updateTimeline is already running, we'll use the newest parameters, and run updateTimeline later
+	 * Returns a promise that will resolve after updateTimeline has run
+	 * @param fullConfig
+	 * @param runtimeData
+	 */
+	triggerUpdateTimeline(fullConfig: FullConfig, runtimeData: RunTimeData): Promise<void> {
+		const checkRunUpdateTimeline = () => {
+			if (!this._updateTimelineRunning && this._nextUpdateTimeline) {
+				this._updateTimelineRunning = true
+
+				const nextUpdateTimeline = this._nextUpdateTimeline
+				delete this._nextUpdateTimeline
+
+				this.updateTimeline(nextUpdateTimeline.fullConfig, nextUpdateTimeline.runtimeData)
+					.then(() => {
+						this._updateTimelineRunning = false
+						_.each(nextUpdateTimeline.resolve, (resolve) => resolve())
+						checkRunUpdateTimeline()
+					})
+					.catch((e) => {
+						this._updateTimelineRunning = false
+						_.each(nextUpdateTimeline.reject, (reject) => reject(e))
+						checkRunUpdateTimeline()
+					})
+			}
+		}
+
+		return new Promise((resolve, reject) => {
+			if (!this._nextUpdateTimeline)
+				this._nextUpdateTimeline = {
+					fullConfig: fullConfig,
+					runtimeData: runtimeData,
+					resolve: [],
+					reject: []
+				}
+
+			// Set the latest parameters, as they are most recent:
+			this._nextUpdateTimeline.fullConfig = fullConfig
+			this._nextUpdateTimeline.runtimeData = runtimeData
+
+			this._nextUpdateTimeline.resolve.push(resolve)
+			this._nextUpdateTimeline.reject.push(reject)
+
+			checkRunUpdateTimeline()
+		})
 	}
 	/** Calculate new timeline and send it into TSR */
-	updateTimeline(fullConfig: FullConfig, runtimeData: RunTimeData): void {
-		const sources: Sources = fullConfig.sources;
-		const cutouts: Cutouts = fullConfig.cutouts;
-		const outputs: Outputs = fullConfig.outputs;
-		const settings: Settings = fullConfig.settings;
+	private async updateTimeline(fullConfig: FullConfig, runtimeData: RunTimeData): Promise<void> {
+		const sources: Sources = fullConfig.sources
+		const cutouts: Cutouts = fullConfig.cutouts
+		const outputs: Outputs = fullConfig.outputs
+		const settings: Settings = fullConfig.settings
 
-		this.mappings = {};
-		this.timeline = [];
-		this.refer.reset();
+		this.mappings = {}
+		this.timeline = []
+		this.refer.reset()
 
-		let routeLayer = settings.channelForRoutesStartLayer;
-		const prepareContentRoute = (input: SourceInputAny) => {
-			routeLayer++;
+		let routeLayer = settings.channelForRoutesStartLayer
+		let routeChannel = settings.channelForRoutes
+		const prepareContentRoute = async (source: Source, sourceId: string) => {
+			const input: SourceInputAny = source.input
 
-			const layer = 'output' + routeLayer + '_content';
+			const refId = this.refer.getSourceRef(input)
 
-			const mixer: Mixer = {
-				opacity: 0,
-				volume: 0
-			};
+			const mixer: Mixer = {}
 
-			const refId = this.refer.getSourceRef(input);
+			if (!settings.useImageProviderForRoutes) {
+				const url = `${getImageProviderLocation(settings)}/custom/${sourceId}`
+
+				const response = await axios.get(url)
+				// console.log('response.data', response.data);
+				// info.regions
+
+				const data: any = response.data
+				const region = _.find(data.regions as any[], (region) => region.contentId === sourceId)
+				if (!region) throw new Error(`Region "${sourceId}" not found`)
+				routeChannel = region.region.channel
+				routeLayer = region.region.layer
+
+				mixer.volume = 0
+			} else {
+				routeLayer++
+				mixer.opacity = 0
+				mixer.volume = 0
+			}
+
+			console.log('prepareContentRoute', refId)
+
+			const layer = 'output' + routeLayer + '_content'
+
 			if (
-				!this.refer.getRef(refId, layer) // If there already is a reference, do nothing
+				!this.refer.getRef(refId, layer) // If there already is a reference, do nothing as the source is already playing in Caspar
 			) {
 				this.mappings[layer] = {
 					device: DeviceType.CASPARCG,
-					deviceId: 'casparcg0',
-					channel: settings.channelForRoutes,
+					deviceId: CASPARCG_DEVICE_ID,
+					channel: routeChannel,
 					layer: routeLayer
-				};
-				this.timeline.push(this.refer.getSource(input, layer, mixer));
+				}
+				this.timeline.push(this.refer.getSource(input, layer, mixer))
 			}
-		};
+		}
 		const shouldUseTransition = (layer: string, source: Source): boolean => {
-			const mapping = this.mappings[layer];
-			const channelLayerId = 'oldSource_' + mapping.channel * 1000 + mapping.layer;
+			const mapping = this.mappings[layer]
+			const channelLayerId = 'oldSource_' + mapping.channel * 1000 + mapping.layer
 
 			if (_.isEqual(this._memorySources[channelLayerId], source.input)) {
-				return true;
+				return true
 			} else {
-				this._memorySources[channelLayerId] = source.input;
-				return false;
+				this._memorySources[channelLayerId] = source.input
+				return false
 			}
-		};
+		}
 
-		_.each(sources, (source) => {
-			prepareContentRoute(source.input);
-		});
+		for (const sourceId in sources) {
+			const source = sources[sourceId]
+			await prepareContentRoute(source, sourceId)
+		}
 
 		_.each(outputs, (output: OutputAny, outputi: number) => {
 			if (output.type === OutputType.CUTOUT) {
-				const layer = 'output' + outputi + '_source';
+				const layer = 'output' + outputi + '_source'
 				this.mappings[layer] = {
 					device: DeviceType.CASPARCG,
-					deviceId: 'casparcg0',
+					deviceId: CASPARCG_DEVICE_ID,
 					channel: output.casparChannel,
 					layer: 10
-				};
+				}
 
-				const cutoutId: string | undefined = runtimeData.pgmCutout || output.cutout.cutoutId;
+				const cutoutId: string | undefined = runtimeData.pgmCutout || output.cutout.cutoutId
 				if (cutoutId) {
 					// const cutoutId = output.cutout.cutoutId
-					const cutout = cutouts[cutoutId];
-					if (!cutout) throw Error(`cutout "${cutoutId} not found!`);
-					const source = sources[cutout.source];
-					if (!source) throw Error(`source "${cutout.source} not found!`);
+					const cutout = cutouts[cutoutId]
+					if (!cutout) throw Error(`cutout "${cutoutId} not found!`)
+					const source = sources[cutout.source]
+					if (!source) throw Error(`source "${cutout.source} not found!`)
 
-					const useTransition = shouldUseTransition(layer, source);
+					const useTransition = shouldUseTransition(layer, source)
 
-					const cutoutInOutput = output.cutout;
+					const cutoutInOutput = output.cutout
 
-					const sourceTransform = this._sourceTransform(source);
-					const cutoutTransform = this._cutoutTransform(source, sourceTransform, cutout);
+					const sourceTransform = this._sourceTransform(source)
+					const cutoutTransform = this._cutoutTransform(source, sourceTransform, cutout)
 
-					const matrix0 = compose(rotateDEG(cutout.outputRotation, 0, 0));
-					const rotatedCutout = applyToPoint(matrix0, { x: cutout.width, y: cutout.height });
+					const matrix0 = compose(rotateDEG(cutout.outputRotation, 0, 0))
+					const rotatedCutout = applyToPoint(matrix0, { x: cutout.width, y: cutout.height })
 					const scaleToFill =
 						cutoutInOutput.scale ||
 						Math.min(
 							output.width / Math.abs(rotatedCutout['x']),
 							output.height / Math.abs(rotatedCutout['y'])
-						);
+						)
 
 					const viewportTransform = compose(
 						translate(0.5, 0.5),
@@ -174,152 +256,152 @@ export class TSRController {
 						translate(cutoutInOutput.x, cutoutInOutput.y),
 						rotateDEG(cutout.outputRotation, 0.5, 0.5),
 						scale(scaleToFill)
-					);
-					const outputTransform = compose(viewportTransform, cutoutTransform);
+					)
+					const outputTransform = compose(viewportTransform, cutoutTransform)
 
 					const mixerPosition = this._casparTransformPosition(
 						source,
 						outputTransform,
 						useTransition
-					);
-					const mixerClipping = this._casparTransformClip(cutout, viewportTransform, useTransition);
+					)
+					const mixerClipping = this._casparTransformClip(cutout, viewportTransform, useTransition)
 
 					this.timeline.push(
 						this.refer.getSource(source.input, layer, {
 							...mixerPosition,
 							...mixerClipping
 						})
-					);
+					)
 				} else {
 					// No cutout on program
 				}
 			} else if (output.type === OutputType.MULTIVIEW) {
 				if (output.background) {
-					const layerMultiviewBg = 'output' + outputi + '_mvbg';
+					const layerMultiviewBg = 'output' + outputi + '_mvbg'
 					this.mappings[layerMultiviewBg] = {
 						device: DeviceType.CASPARCG,
-						deviceId: 'casparcg0',
+						deviceId: CASPARCG_DEVICE_ID,
 						channel: output.casparChannel,
 						layer: 10
-					};
-					this.timeline.push(this.refer.media(layerMultiviewBg, output.background));
+					}
+					this.timeline.push(this.refer.media(layerMultiviewBg, output.background))
 				}
 
 				if (output.cutouts.length) {
 					_.each(output.cutouts, (cutoutOutput, i) => {
-						const layerBase = 100 + 10 * i;
-						const layer = 'output' + outputi + '_mv_' + cutoutOutput.cutoutId;
-						const layerBg = 'output' + outputi + '_mvbg_' + cutoutOutput.cutoutId;
+						const layerBase = 100 + 10 * i
+						const layer = 'output' + outputi + '_mv_' + cutoutOutput.cutoutId
+						const layerBg = 'output' + outputi + '_mvbg_' + cutoutOutput.cutoutId
 						this.mappings[layerBg] = {
 							device: DeviceType.CASPARCG,
-							deviceId: 'casparcg0',
+							deviceId: CASPARCG_DEVICE_ID,
 							channel: output.casparChannel,
 							layer: layerBase + 0
-						};
+						}
 						this.mappings[layer] = {
 							device: DeviceType.CASPARCG,
-							deviceId: 'casparcg0',
+							deviceId: CASPARCG_DEVICE_ID,
 							channel: output.casparChannel,
 							layer: layerBase + 1
-						};
+						}
 
-						const cutout = cutouts[cutoutOutput.cutoutId];
-						if (!cutout) throw Error(`cutout "${cutoutOutput.cutoutId} not found!`);
-						const source = sources[cutout.source];
-						if (!source) throw Error(`source "${cutout.source} not found!`);
+						const cutout = cutouts[cutoutOutput.cutoutId]
+						if (!cutout) throw Error(`cutout "${cutoutOutput.cutoutId} not found!`)
+						const source = sources[cutout.source]
+						if (!source) throw Error(`source "${cutout.source} not found!`)
 
-						const useTransition = shouldUseTransition(layer, source);
+						const useTransition = shouldUseTransition(layer, source)
 
-						const sourceTransform = this._sourceTransform(source);
-						const cutoutTransform = this._cutoutTransform(source, sourceTransform, cutout);
+						const sourceTransform = this._sourceTransform(source)
+						const cutoutTransform = this._cutoutTransform(source, sourceTransform, cutout)
 
 						const viewportTransform = compose(
 							translate(0.5, 0.5),
 							scale(1 / output.width, 1 / output.height),
 							translate(cutoutOutput.x, cutoutOutput.y),
 							scale(cutoutOutput.scale)
-						);
-						const outputTransform = compose(viewportTransform, cutoutTransform);
+						)
+						const outputTransform = compose(viewportTransform, cutoutTransform)
 
 						const mixerPosition = this._casparTransformPosition(
 							source,
 							outputTransform,
 							useTransition
-						);
+						)
 						const mixerClipping = this._casparTransformClip(
 							cutout,
 							viewportTransform,
 							useTransition
-						);
+						)
 						const mixerClippingBg = this._casparTransformClip(
 							cutout,
 							viewportTransform,
 							useTransition
-						);
+						)
 
 						// Black background behind clip:
-						this.timeline.push(this.refer.media(layerBg, 'black', mixerClippingBg));
+						this.timeline.push(this.refer.media(layerBg, 'black', mixerClippingBg))
 						this.timeline.push(
 							this.refer.getSource(source.input, layer, {
 								...mixerPosition,
 								...mixerClipping
 							})
-						);
-					});
+						)
+					})
 				}
 			}
-		});
+		})
 
 		_.each(this.timeline, (tlObj, i) => {
-			if (!tlObj.id) tlObj.id = 'Unnamed' + i;
-		});
+			if (!tlObj.id) tlObj.id = 'Unnamed' + i
+		})
 
 		// Send mappings and timeline to TSR:
-		this.tsr.setMapping(this.mappings);
-		this.tsr.timeline = this.timeline;
+		this.tsr.setMapping(this.mappings)
+		this.tsr.timeline = this.timeline
 	}
 
 	private _addTSRDevice(deviceId: string, options: DeviceOptionsAny): void {
 		// console.log('Adding device ' + deviceId)
 
-		if (!options.limitSlowSentCommand) options.limitSlowSentCommand = 40;
-		if (!options.limitSlowFulfilledCommand) options.limitSlowFulfilledCommand = 100;
+		if (!options.limitSlowSentCommand) options.limitSlowSentCommand = 40
+		if (!options.limitSlowFulfilledCommand) options.limitSlowFulfilledCommand = 100
 
 		this.tsr
 			.addDevice(deviceId, options)
 			.then(async (device: DeviceContainer) => {
-				this._tsrDevices[deviceId] = device;
+				this._tsrDevices[deviceId] = device
 
 				await device.device.on('connectionChanged', (v: any) => {
-					console.log(`Device ${device.deviceId}: Connection changed: ${v}`);
-				});
+					console.log(`Device ${device.deviceId}: Connection changed: ${v}`)
+				})
 				await device.device.on('connectionChanged', (status: any) => {
-					console.log(`Device ${device.deviceId}: status changed: ${status}`);
-				});
+					console.log(`Device ${device.deviceId}: status changed: ${status}`)
+				})
 				await device.device.on('slowCommand', (msg: string) => {
 					// console.log(`Device ${device.deviceId}: slow command: ${msg}`)
-				});
+				})
 
-				console.log(`Device ${device.deviceId}: status`, await device.device.getStatus());
+				console.log(`Device ${device.deviceId}: status`, await device.device.getStatus())
 			})
 			.catch((e) => {
-				console.error(`Error when adding device "${deviceId}"`, e);
-			});
+				console.error(`Error when adding device "${deviceId}"`, e)
+			})
 	}
 	private _removeTSRDevice(deviceId: string): void {
 		if (this._tsrDevices[deviceId]) {
 			this._tsrDevices[deviceId].device.terminate().catch((e) => {
-				console.error('Error when removing device: ' + e);
-			});
+				console.error('Error when removing device: ' + e)
+			})
 		}
-		delete this._tsrDevices[deviceId];
+		delete this._tsrDevices[deviceId]
 	}
 	private _sourceTransform(source: Source): Matrix {
 		// Transform from source to view-space:
-		return compose(rotateDEG(-source.rotation));
+		return compose(rotateDEG(-source.rotation))
 	}
 	private _cutoutTransform(source: Source, sourceTransform: Matrix, cutout: Cutout): Matrix {
-		return compose(translate(-cutout.x, -cutout.y), sourceTransform);
+		return compose(translate(-cutout.x, -cutout.y), sourceTransform)
 	}
 	private _casparTransformPosition(
 		source: { width: number; height: number },
@@ -327,15 +409,15 @@ export class TSRController {
 		useTransition: boolean
 	): Mixer {
 		// Apply coordinates to CasparCG coordinate system:
-		const x0 = -source.width / 2;
-		const y0 = -source.height / 2;
-		const x1 = source.width / 2;
-		const y1 = source.height / 2;
+		const x0 = -source.width / 2
+		const y0 = -source.height / 2
+		const x1 = source.width / 2
+		const y1 = source.height / 2
 
-		const topLeft = applyToPoint(outputTransform, { x: x0, y: y0 });
-		const topRight = applyToPoint(outputTransform, { x: x1, y: y0 });
-		const bottomLeft = applyToPoint(outputTransform, { x: x0, y: y1 });
-		const bottomRight = applyToPoint(outputTransform, { x: x1, y: y1 });
+		const topLeft = applyToPoint(outputTransform, { x: x0, y: y0 })
+		const topRight = applyToPoint(outputTransform, { x: x1, y: y0 })
+		const bottomLeft = applyToPoint(outputTransform, { x: x0, y: y1 })
+		const bottomRight = applyToPoint(outputTransform, { x: x1, y: y1 })
 
 		const mixer: Mixer = {
 			...this._casparTransformTransition(useTransition),
@@ -349,8 +431,8 @@ export class TSRController {
 				bottomLeftX: bottomLeft['x'],
 				bottomLeftY: bottomLeft['y']
 			}
-		};
-		return mixer;
+		}
+		return mixer
 	}
 	private _casparTransformClip(
 		clipDimensions: { width: number; height: number },
@@ -359,22 +441,22 @@ export class TSRController {
 	): Mixer {
 		// Apply coordinates to CasparCG coordinate system:
 
-		const x0 = -clipDimensions.width / 2;
-		const y0 = -clipDimensions.height / 2;
-		const x1 = clipDimensions.width / 2;
-		const y1 = clipDimensions.height / 2;
+		const x0 = -clipDimensions.width / 2
+		const y0 = -clipDimensions.height / 2
+		const x1 = clipDimensions.width / 2
+		const y1 = clipDimensions.height / 2
 
-		const u0 = applyToPoint(transform, { x: x0, y: y0 });
-		const u1 = applyToPoint(transform, { x: x1, y: y1 });
+		const u0 = applyToPoint(transform, { x: x0, y: y0 })
+		const u1 = applyToPoint(transform, { x: x1, y: y1 })
 
 		const topLeft = {
 			x: Math.min(u0['x'], u1['x']),
 			y: Math.min(u0['y'], u1['y'])
-		};
+		}
 		const bottomRight = {
 			x: Math.max(u0['x'], u1['x']),
 			y: Math.max(u0['y'], u1['y'])
-		};
+		}
 
 		const mixer: Mixer = {
 			...this._casparTransformTransition(useTransition),
@@ -384,13 +466,13 @@ export class TSRController {
 				width: bottomRight.x - topLeft.x,
 				height: bottomRight.y - topLeft.y
 			}
-		};
-		return mixer;
+		}
+		return mixer
 	}
 	private _casparTransformTransition(useTransition: boolean): Mixer {
-		if (!useTransition) return {};
+		if (!useTransition) return {}
 		// tmp: disable transition
-		return {};
+		return {}
 		/*
 		return {
 			inTransition: {
@@ -407,9 +489,9 @@ export class TSRController {
 }
 
 export interface DecklinkInputRefs {
-	[refId: string]: string;
+	[refId: string]: string
 }
 export interface RunTimeData {
-	pvwCutout?: string;
-	pgmCutout?: string;
+	pvwCutout?: string
+	pgmCutout?: string
 }

--- a/server/TSRController.ts
+++ b/server/TSRController.ts
@@ -22,7 +22,6 @@ import { Matrix, applyToPoint, compose, rotateDEG, scale, translate } from 'tran
 
 import { CasparReferrer } from './CasparReferrer'
 import _ from 'underscore'
-import querystring from 'querystring'
 import { getImageProviderLocation } from './imageProvider'
 import axios from 'axios'
 

--- a/server/api.ts
+++ b/server/api.ts
@@ -1,45 +1,44 @@
-import { ChannelFormat } from 'timeline-state-resolver';
+import { ChannelFormat } from 'timeline-state-resolver'
 
 export interface FullConfig {
-	cutouts: Cutouts;
-	outputs: Outputs;
-	sources: Sources;
-	settings: Settings;
+	cutouts: Cutouts
+	outputs: Outputs
+	sources: Sources
+	settings: Settings
 }
 export interface FullConfigClient extends FullConfig {
 	sourceReferenceLayers: {
 		[sourceId: string]: {
-			channel: number;
-			layer: number;
-		};
-	};
+			contentId: string
+		}
+	}
 }
 
 export interface Sources {
-	[sourceId: string]: Source;
+	[sourceId: string]: Source
 }
 /**
  * The Source describes what's coming in
  */
 export interface Source {
 	/** Title/Name, to be used in GUI  */
-	title: string;
+	title: string
 
 	/** Rotation, in degrees. For example, if source input has been rotated CW, this should be set to 90 */
-	rotation: number;
+	rotation: number
 
 	/** Width, in px, oriented as "after having fixed the rotation" */
-	width: number;
+	width: number
 	/** Height, in px, oriented as "after having fixed the rotation" */
-	height: number;
+	height: number
 
 	/** Input properites, used in Caspar */
-	input: SourceInputAny;
+	input: SourceInputAny
 }
 
-export type SourceInputAny = SourceInputDecklink | SourceInputMedia | SourceInputHtmlPage;
+export type SourceInputAny = SourceInputDecklink | SourceInputMedia | SourceInputHtmlPage
 export interface SourceInputBase {
-	type: SourceInputType;
+	type: SourceInputType
 }
 export enum SourceInputType {
 	DECKLINK = 'decklink',
@@ -47,87 +46,89 @@ export enum SourceInputType {
 	HTML_PAGE = 'html_page'
 }
 export interface SourceInputDecklink extends SourceInputBase {
-	type: SourceInputType.DECKLINK;
-	format: ChannelFormat;
-	device: number;
+	type: SourceInputType.DECKLINK
+	format: ChannelFormat
+	device: number
 }
 export interface SourceInputMedia extends SourceInputBase {
-	type: SourceInputType.MEDIA;
-	file: string;
+	type: SourceInputType.MEDIA
+	file: string
 }
 export interface SourceInputHtmlPage extends SourceInputBase {
-	type: SourceInputType.HTML_PAGE;
-	url: string;
+	type: SourceInputType.HTML_PAGE
+	url: string
 }
 
 export interface Cutouts {
-	[cutoutId: string]: Cutout;
+	[cutoutId: string]: Cutout
 }
 export interface Cutout {
-	source: string;
+	source: string
 	/** Cutout position, (relative to the Source coordinate-space) */
-	x: number;
+	x: number
 	/** Cutout position, (relative to the Source coordinate-space) */
-	y: number;
+	y: number
 	/** Cutout width, (relative to the Source coordinate-space) */
-	width: number;
+	width: number
 	/** Cutout height, (relative to the Source coordinate-space) */
-	height: number;
+	height: number
 	/** Scaling of cutout in output */
-	scale?: number;
+	scale?: number
 
 	/** How the Cutout will be oriented in the output */
-	outputRotation: number;
+	outputRotation: number
 }
 
 export interface CutoutInOutput {
-	cutoutId?: string;
+	cutoutId?: string
 	/** Position of cutout in Output, in screen coordinates */
-	x: number;
+	x: number
 	/** Position of cutout in Output, in screen coordinates */
-	y: number;
+	y: number
 	/** Scaling of cutout in output. Omit to automatically scale to fill */
-	scale: number;
+	scale: number
 }
-export type Outputs = OutputAny[];
+export type Outputs = OutputAny[]
 
-export type OutputAny = OutputCutout | OutputMultiview;
+export type OutputAny = OutputCutout | OutputMultiview
 export interface OutputBase {
-	type: OutputType;
-	casparChannel: number;
+	type: OutputType
+	casparChannel: number
 	/** Width of the CasparCG Channel */
-	width: number;
+	width: number
 	/** Height of the CasparCG Channel */
-	height: number;
+	height: number
 }
 export enum OutputType {
 	CUTOUT = 'cutout',
 	MULTIVIEW = 'multiview'
 }
 export interface OutputCutout extends OutputBase {
-	type: OutputType.CUTOUT;
-	cutout: CutoutInOutput;
+	type: OutputType.CUTOUT
+	cutout: CutoutInOutput
 }
 export interface OutputMultiview extends OutputBase {
-	type: OutputType.MULTIVIEW;
-	cutouts: CutoutInOutput[];
+	type: OutputType.MULTIVIEW
+	cutouts: CutoutInOutput[]
 
 	/** Background to put behind the multiview */
-	background?: string;
+	background?: string
 }
 
 export interface Settings {
-	/** The channel to use for putting inputs on (and route the content from there) */
-	channelForRoutes: number;
-	/** What layer to start on */
-	channelForRoutesStartLayer: number;
+	useImageProviderForRoutes?: boolean
 
-	casparCG: NetworkResource;
-	imageProvider: NetworkResource;
+	/** The channel to use for putting inputs on (and route the content from there) */
+	channelForRoutes: number
+	/** What layer to start on */
+	channelForRoutesStartLayer: number
+
+	casparCG: NetworkResource
+	imageProvider: NetworkResource
 }
 
 export interface NetworkResource {
-	hostname: string;
-	port: number;
-	protocol?: string;
+	hostname: string
+	port: number
+	protocol?: string
 }

--- a/server/dataHandler.ts
+++ b/server/dataHandler.ts
@@ -1,24 +1,24 @@
-import * as chokidar from 'chokidar';
-import * as fs from 'fs';
-import * as path from 'path';
-import * as util from 'util';
+import * as chokidar from 'chokidar'
+import * as fs from 'fs'
+import * as path from 'path'
+import * as util from 'util'
 
-import { Cutout, Cutouts, FullConfig, Outputs, Sources, Settings } from './api';
+import { Cutout, Cutouts, FullConfig, Outputs, Sources, Settings } from './api'
 
-const fsReadFile = util.promisify(fs.readFile);
-const fsWriteFile = util.promisify(fs.writeFile);
+const fsReadFile = util.promisify(fs.readFile)
+const fsWriteFile = util.promisify(fs.writeFile)
 
 export class DataHandler {
-	private _onConfigChangedTimeout?: NodeJS.Timeout;
-	private _lastTimeStoredCutouts = 0;
+	private _onConfigChangedTimeout?: NodeJS.Timeout
+	private _lastTimeStoredCutouts = 0
 
-	private _localConfig: FullConfig;
+	private _localConfig: FullConfig
 
 	constructor(private _basePath: string) {
-		this._getConfigCutouts().catch(console.error);
+		this._getConfigCutouts().catch(console.error)
 	}
 	public getConfig(): FullConfig {
-		return this._localConfig;
+		return this._localConfig
 	}
 	public async updateConfig(): Promise<void> {
 		this._localConfig = {
@@ -26,76 +26,76 @@ export class DataHandler {
 			outputs: await this._getConfigOutputs(),
 			sources: await this._getConfigSources(),
 			settings: await this._getConfigSettings()
-		};
+		}
 	}
 	public onConfigChanged(callback: () => void): void {
 		const triggerCallback = (): void => {
 			if (this._onConfigChangedTimeout) {
-				clearTimeout(this._onConfigChangedTimeout);
+				clearTimeout(this._onConfigChangedTimeout)
 			}
 			this._onConfigChangedTimeout = setTimeout(() => {
 				this.updateConfig()
 					.then(() => {
-						callback();
+						callback()
 					})
-					.catch(console.error);
-			}, 500);
-		};
+					.catch(console.error)
+			}, 500)
+		}
 		chokidar.watch(this._getConfigPath('outputs.json')).on('all', () => {
-			triggerCallback();
-		});
+			triggerCallback()
+		})
 		chokidar.watch(this._getConfigPath('sources.json')).on('all', () => {
-			triggerCallback();
-		});
+			triggerCallback()
+		})
 		chokidar.watch(this._getConfigPath('settings.json')).on('all', () => {
-			triggerCallback();
-		});
+			triggerCallback()
+		})
 
 		chokidar.watch(this._getConfigPath('cutouts.json')).on('all', () => {
 			if (Date.now() - this._lastTimeStoredCutouts > 1000) {
-				triggerCallback();
+				triggerCallback()
 			}
-		});
+		})
 	}
 
 	async setConfigCutout(cutoutId: string, cutout: Cutout): Promise<void> {
-		this._localConfig.cutouts[cutoutId] = cutout;
-		this._lastTimeStoredCutouts = Date.now();
+		this._localConfig.cutouts[cutoutId] = cutout
+		this._lastTimeStoredCutouts = Date.now()
 		await this._storeConfig('cutouts.json', {
 			note:
 				'This file is not intended to be manually edited, it will update when the user makes changes in the UI',
 			cutouts: this._localConfig.cutouts
-		});
+		})
 	}
 	private async _getConfigCutouts(): Promise<Cutouts> {
 		// TODO: add data verifications here..
-		return (await this._getConfig('cutouts.json')).cutouts as Cutouts;
+		return (await this._getConfig('cutouts.json')).cutouts as Cutouts
 	}
 	private async _getConfigOutputs(): Promise<Outputs> {
 		// TODO: add data verifications here..
-		return (await this._getConfig('outputs.json')).outputs as Outputs;
+		return (await this._getConfig('outputs.json')).outputs as Outputs
 	}
 	private async _getConfigSources(): Promise<Sources> {
 		// TODO: add data verifications here..
-		return (await this._getConfig('sources.json')).sources as Sources;
+		return (await this._getConfig('sources.json')).sources as Sources
 	}
 	private async _getConfigSettings(): Promise<Settings> {
 		// TODO: add data verifications here..
-		return (await this._getConfig('settings.json')).settings as Settings;
+		return (await this._getConfig('settings.json')).settings as Settings
 	}
 
 	private async _getConfig(fileName: string): Promise<any> {
 		const text = await fsReadFile(this._getConfigPath(fileName), {
 			encoding: 'utf-8'
-		});
-		return JSON.parse(text);
+		})
+		return JSON.parse(text)
 	}
 	private async _storeConfig(fileName: string, data: Record<string, any>): Promise<void> {
 		await fsWriteFile(this._getConfigPath(fileName), JSON.stringify(data, null, 2), {
 			encoding: 'utf-8'
-		});
+		})
 	}
 	private _getConfigPath(fileName: string): string {
-		return path.join(this._basePath, '/config', fileName);
+		return path.join(this._basePath, '/config', fileName)
 	}
 }

--- a/server/imageProvider.ts
+++ b/server/imageProvider.ts
@@ -1,0 +1,8 @@
+import { Settings } from './api'
+
+export function getImageProviderLocation(settings: Settings) {
+	const protocol = settings.imageProvider.protocol ? `${settings.imageProvider.protocol}://` : ''
+	const port = settings.imageProvider.port ? `:${settings.imageProvider.port}` : ''
+
+	return `${protocol}${settings.imageProvider.hostname}${port}`
+}

--- a/server/imageProvider.ts
+++ b/server/imageProvider.ts
@@ -1,6 +1,6 @@
 import { Settings } from './api'
 
-export function getImageProviderLocation(settings: Settings) {
+export function getImageProviderLocation(settings: Settings): string {
 	const protocol = settings.imageProvider.protocol ? `${settings.imageProvider.protocol}://` : ''
 	const port = settings.imageProvider.port ? `:${settings.imageProvider.port}` : ''
 

--- a/server/main.ts
+++ b/server/main.ts
@@ -1,27 +1,27 @@
-import * as chokidar from 'chokidar';
+import * as chokidar from 'chokidar'
 
-import { BrowserWindow, ipcMain } from 'electron';
-import { Cutout, FullConfigClient } from './api';
+import { BrowserWindow, ipcMain } from 'electron'
+import { Cutout, FullConfigClient } from './api'
 
-import { DataHandler } from './dataHandler';
-import { TSRController, RunTimeData } from './TSRController';
-import _ from 'underscore';
+import { DataHandler } from './dataHandler'
+import { TSRController, RunTimeData } from './TSRController'
+import _ from 'underscore'
 
 export default class Main {
-	static mainWindow: Electron.BrowserWindow | null;
-	static application: Electron.App;
-	static BrowserWindow: typeof BrowserWindow;
+	static mainWindow: Electron.BrowserWindow | null
+	static application: Electron.App
+	static BrowserWindow: typeof BrowserWindow
 
-	static tsrController: TSRController;
-	static dataHandler: DataHandler;
+	static tsrController: TSRController
+	static dataHandler: DataHandler
 
-	static runtimeData: RunTimeData = {};
+	static runtimeData: RunTimeData = {}
 
 	private static onWindowAllClosed(): void {
 		// On macOS it is common for applications and their menu bar
 		// to stay active until the user quits explicitly with Cmd + Q
 		if (process.platform !== 'darwin') {
-			Main.application.quit();
+			Main.application.quit()
 		}
 	}
 
@@ -29,9 +29,9 @@ export default class Main {
 		// Dereference the window object, usually you would store windows
 		// in an array if your app supports multi windows, this is the time
 		// when you should delete the corresponding element.
-		Main.mainWindow = null;
+		Main.mainWindow = null
 
-		Main.tsrController.destroy().catch(console.error);
+		Main.tsrController.destroy().catch(console.error)
 	}
 
 	private static onReady(): void {
@@ -41,96 +41,91 @@ export default class Main {
 			webPreferences: {
 				nodeIntegration: true
 			}
-		});
-		Main.mainWindow.loadFile('index.html');
-		Main.mainWindow.on('closed', Main.onClose);
+		})
+		Main.mainWindow.loadFile('index.html')
+		Main.mainWindow.on('closed', Main.onClose)
 
 		chokidar.watch('/config.json').on('all', (event, path) => {
-			console.log(event, path);
-		});
+			console.log(event, path)
+		})
 
 		Main.dataHandler
 			.updateConfig()
 			.then(() => {
-				return Main.tsrController.init(Main.dataHandler.getConfig());
+				return Main.tsrController.init(Main.dataHandler.getConfig())
 			})
-			.catch(console.error);
+			.catch(console.error)
 
 		ipcMain.on('initialize', (event) => {
-			console.log('Initializing...');
+			console.log('Initializing...')
 
 			Main.dataHandler.onConfigChanged(() => {
-				console.log('config changed, reloading..');
+				console.log('config changed, reloading..')
 
-				Main.updateTimeline();
+				Main.updateTimeline()
+					.then(() => {
+						const fullConfig = Main.dataHandler.getConfig()
 
-				const fullConfig = Main.dataHandler.getConfig();
+						const fullConfigClient: FullConfigClient = _.extend(
+							{
+								sourceReferenceLayers: {}
+							},
+							fullConfig
+						)
 
-				const fullConfigClient: FullConfigClient = _.extend(
-					{
-						sourceReferenceLayers: {}
-					},
-					fullConfig
-				);
-
-				// Find where the sources have been mapped up in CasparCG, so we know which layers to fetch the images from in the UI:
-				_.each(fullConfig.sources, (source, sourceId) => {
-					const refId = Main.tsrController.refer.getSourceRef(source.input);
-					const ref = Main.tsrController.refer.getRef(refId, '');
-					if (ref) {
-						const mapping = Main.tsrController.mappings[ref.content.mappedLayer];
-						if (mapping) {
+						// Find where the sources have been mapped up in CasparCG, so we know which layers to fetch the images from in the UI:
+						_.each(fullConfig.sources, (_source, sourceId) => {
 							fullConfigClient.sourceReferenceLayers[sourceId] = {
-								channel: mapping.channel,
-								layer: mapping.layer
-							};
-						}
-					}
-				});
-
-				event.reply('new-config', fullConfigClient);
-				event.reply('backend-ready');
-			});
-		});
+								contentId: sourceId
+							}
+						})
+						event.reply('new-config', fullConfigClient)
+						event.reply('backend-ready')
+					})
+					.catch(console.error)
+			})
+		})
 		ipcMain.on('update-cutout', (event, cutoutId: string, cutout: Cutout) => {
-			// console.log('update-cutout handler', cutoutId, cutout);
 			Main.dataHandler
 				.setConfigCutout(cutoutId, cutout)
 				.then(() => {
 					// const fullConfig = Main.dataHandler.getConfig();
 					// console.log('fullConfig.cutouts', fullConfig.cutouts);
-					Main.updateTimeline();
+					Main.triggerUpdateTimeline()
 				})
-				.catch(console.error);
-		});
+				.catch(console.error)
+		})
 		ipcMain.on('take', (event, cutoutId: string) => {
-			console.log('TAKE', cutoutId);
-			Main.runtimeData.pgmCutout = cutoutId;
+			console.log('TAKE', cutoutId)
+			Main.runtimeData.pgmCutout = cutoutId
 
-			Main.updateTimeline();
-		});
+			Main.triggerUpdateTimeline()
+		})
 	}
 
-	private static updateTimeline(): void {
-		Main.tsrController.updateTimeline(Main.dataHandler.getConfig(), Main.runtimeData);
+	private static triggerUpdateTimeline(): void {
+		Main.updateTimeline().catch(console.error)
+	}
+	private static updateTimeline(): Promise<void> {
+		return Main.tsrController.triggerUpdateTimeline(Main.dataHandler.getConfig(), Main.runtimeData)
 	}
 
 	// On macOS it's common to re-create a window in the app when the
 	// dock icon is clicked and there are no other windows open.
 	private static onActivate(): void {
 		if (Main.mainWindow === null) {
-			Main.onReady();
+			Main.onReady()
 		}
 	}
 
 	static main(app: Electron.App, browserWindow: typeof BrowserWindow): void {
-		Main.BrowserWindow = browserWindow;
-		Main.application = app;
-		Main.application.on('window-all-closed', Main.onWindowAllClosed);
-		Main.application.on('ready', Main.onReady);
-		Main.application.on('activate', Main.onActivate);
+		Main.BrowserWindow = browserWindow
+		Main.application = app
+		Main.application.on('window-all-closed', Main.onWindowAllClosed)
+		Main.application.on('ready', Main.onReady)
+		Main.application.on('activate', Main.onActivate)
 
-		Main.tsrController = new TSRController();
-		Main.dataHandler = new DataHandler(app.getAppPath());
+		Main.tsrController = new TSRController()
+		Main.dataHandler = new DataHandler(app.getAppPath())
 	}
 }

--- a/serverOnly.ts
+++ b/serverOnly.ts
@@ -1,19 +1,19 @@
-import { DataHandler } from './server/dataHandler';
-import { TSRController } from './server/TSRController';
+import { DataHandler } from './server/dataHandler'
+import { TSRController } from './server/TSRController'
 
 // Note: this is a temporary file, that
-const dataHandler = new DataHandler('./');
-const tsrController = new TSRController();
+const dataHandler = new DataHandler('./')
+const tsrController = new TSRController()
 
 dataHandler
 	.updateConfig()
 	.then(() => {
-		return tsrController.init(dataHandler.getConfig());
+		return tsrController.init(dataHandler.getConfig())
 	})
-	.catch(console.error);
+	.catch(console.error)
 
 dataHandler.onConfigChanged(() => {
-	console.log('config changed, reloading..');
+	console.log('config changed, reloading..')
 
-	tsrController.updateTimeline(dataHandler.getConfig(), {});
-});
+	tsrController.triggerUpdateTimeline(dataHandler.getConfig(), {})
+})

--- a/shared/events.d.ts
+++ b/shared/events.d.ts
@@ -1,8 +1,8 @@
 export declare class EventNames {
-	static BACKEND_INITIALIZE: string;
-	static BACKEND_READY: string;
-	static SET_PREVIEW: string;
-	static TAKE: string;
-	static UPDATE_CONFIG: string;
-	static UPDATE_CUTOUT: string;
+	static BACKEND_INITIALIZE: string
+	static BACKEND_READY: string
+	static SET_PREVIEW: string
+	static TAKE: string
+	static UPDATE_CONFIG: string
+	static UPDATE_CUTOUT: string
 }

--- a/shared/events.js
+++ b/shared/events.js
@@ -1,4 +1,4 @@
-export { EventNames };
+export { EventNames }
 
 /**
  * Application event names used for communication between the back and front ends.
@@ -23,4 +23,4 @@ const EventNames = {
 
 	/** Update cutout size and position */
 	UPDATE_CUTOUT: 'update-cutout'
-};
+}


### PR DESCRIPTION
This PR changes how the sources are set up in CasparCG.

Before:
* Sources where set up by cutout tool on a channel as hidden layers.
* Sources where routed by image-provider to a grid
* The grid is streamed (through image-provider) to web client of cutout tool
* Sources are routed to PGM-out from the hidden layers

After:
* Cutout-tool asks image-provider where in grid content can be put
* The cutout set sources in the grid directly
* The grid is streamed (through image-provider) to web client of cutout tool (as before)
* Sources are routed to PGM-out from the grid

This saves a few layer-routes in caspar, which gives better performance.